### PR TITLE
Remove unsupported bytes field from ads schema

### DIFF
--- a/tap_google_ads/schemas/ads.json
+++ b/tap_google_ads/schemas/ads.json
@@ -977,12 +977,6 @@
               "integer"
             ]
           },
-          "data": {
-            "type": [
-              "null",
-              "UNSUPPORTED_string"
-            ]
-          },
           "imageUrl": {
             "type": [
               "null",


### PR DESCRIPTION
# Description of change
Removes one field from the ads schema.

# Manual QA steps
 - N/A
 
# Risks
 - N/A
 
# Rollback steps
 - revert this branch
