### PR TITLE
Remove multiple-resource related code

### DIFF
--- a/tap_google_ads/report_definitions.py
+++ b/tap_google_ads/report_definitions.py
@@ -195,7 +195,6 @@ ADGROUP_PERFORMANCE_REPORT_FIELDS = [
     "segments.slot",
     "segments.week",
     "segments.year",
-    # 'label.resource_name',
 ]
 AD_PERFORMANCE_REPORT_FIELDS = [
     "ad_group.base_ad_group",
@@ -368,9 +367,6 @@ AD_PERFORMANCE_REPORT_FIELDS = [
     "segments.slot",
     "segments.week",
     "segments.year",
-    # 'ad_group_criterion.negative',
-    # 'label.resource_name', 'label.name',
-    # 'ad_group_ad.policy_summary.review_state',
 ]
 AGE_RANGE_PERFORMANCE_REPORT_FIELDS = [
     "ad_group.base_ad_group",
@@ -744,8 +740,6 @@ CAMPAIGN_PERFORMANCE_REPORT_FIELDS = [
     "segments.slot",
     "segments.week",
     "segments.year",
-    # 'campaign_criterion.device.type',  # "Not available with 'FROM campaign'. However, you can retrieve device type bid modifiers via 'FROM campaign_criterion' queries.",
-    # 'label.resource_name',  #'Select label.resource_name from the resource campaign_label',
 ]
 CLICK_PERFORMANCE_REPORT_FIELDS = [
     "ad_group.id",
@@ -1155,7 +1149,6 @@ GEO_PERFORMANCE_REPORT_FIELDS = [
     "segments.quarter",
     "segments.week",
     "segments.year",
-    # 'user_location_view.targeting_location',
 ]
 KEYWORDLESS_QUERY_REPORT_FIELDS = [
     "ad_group.id",
@@ -1328,8 +1321,6 @@ KEYWORDS_PERFORMANCE_REPORT_FIELDS = [
     "segments.slot",
     "segments.week",
     "segments.year",
-    # 'label.name',  # Select label.name from the resource ad_group_label
-    # 'label.resource_name',  # Select label.resource_name from the resource ad_group_label
 ]
 LANDING_PAGE_REPORT_FIELDS = [
     "ad_group.id",
@@ -1451,7 +1442,6 @@ PLACEHOLDER_FEED_ITEM_REPORT_FIELDS = [
     "segments.slot",
     "segments.week",
     "segments.year",
-    # "feed_item_target.device", "feed_item_target.keyword.match_type", "feed_item_target.feed_item_target_id", "feed_item_target.keyword.match_type", "feed_item_target.keyword.text", "feed_item_target.feed_item_target_id",  "feed_item_target.ad_schedule", "feed_item_target.ad_group", "feed_item_target.campaign" # feed_item_target.x are available with FROM feed_item_target
 ]
 PLACEHOLDER_REPORT_FIELDS = [
     "ad_group.id",

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -413,114 +413,6 @@ class ReportStream(BaseStream):
         singer.write_state(STATE)
 
 
-class AdGroupPerformanceReport(ReportStream):
-    def add_extra_fields(self, resource_schema):
-        # from the resource ad_group_ad_label
-        field_name = "label.resource_name"
-        self.field_exclusions[field_name] = {}
-        self.schema[field_name] = {"type": ["null", "string"]}
-        self.behavior[field_name] = "ATTRIBUTE"
-
-
-class AdPerformanceReport(ReportStream):
-    def add_extra_fields(self, resource_schema):
-        # from the resource ad_group_ad_label
-        for field_name in ["label.resource_name", "label.name"]:
-            self.field_exclusions[field_name] = {}
-            self.schema[field_name] = {"type": ["null", "string"]}
-            self.behavior[field_name] = "ATTRIBUTE"
-
-        for field_name in [
-            "ad_group_criterion.negative",
-        ]:
-            self.field_exclusions[field_name] = {}
-            self.schema[field_name] = {"type": ["null", "boolean"]}
-            self.behavior[field_name] = "ATTRIBUTE"
-
-
-class AudiencePerformanceReport(ReportStream):
-    "hi"
-    # COMMENT FROM GOOGLE
-    #'bidding_strategy.name must be selected withy the resources  bidding_strategy or campaign.',
-
-    # We think this means
-    # `SELECT bidding_strategy.name from bidding_strategy`
-    #  Not sure how this applies to the campaign resource
-
-    # COMMENT FROM GOOGLE
-    # 'campaign.bidding_strategy.type must be selected withy the resources bidding_strategy or campaign.'
-
-    # We think this means
-    # `SELECT bidding_strategy.type from bidding_strategy`
-
-    # `SELECT campaign.bidding_strategy_type from campaign`
-
-    # 'user_list.name' is a "Segmenting resource"
-    # `select user_list.name from `
-
-
-class CampaignPerformanceReport(ReportStream):
-    # TODO: The sync needs to select from campaign_criterion if campaign_criterion.device.type is selected
-    # TODO: The sync needs to select from campaign_label if label.resource_name
-    def add_extra_fields(self, resource_schema):
-        for field_name in [
-            "campaign_criterion.device.type",
-            "label.resource_name",
-        ]:
-            self.field_exclusions[field_name] = set()
-            self.schema[field_name] = {"type": ["null", "string"]}
-            self.behavior[field_name] = "ATTRIBUTE"
-
-
-class DisplayKeywordPerformanceReport(ReportStream):
-    # TODO: The sync needs to select from bidding_strategy and/or campaign if bidding_strategy.name is selected
-    def add_extra_fields(self, resource_schema):
-        for field_name in [
-            "bidding_strategy.name",
-        ]:
-            self.field_exclusions[field_name] = resource_schema[
-                self.google_ads_resource_names[0]
-            ]["fields"][field_name]["incompatible_fields"]
-            self.schema[field_name] = {"type": ["null", "string"]}
-            self.behavior[field_name] = "SEGMENT"
-
-
-class GeoPerformanceReport(ReportStream):
-    # TODO: The sync needs to select from bidding_strategy and/or campaign if bidding_strategy.name is selected
-    def add_extra_fields(self, resource_schema):
-        for resource_name in self.google_ads_resource_names:
-            for field_name in [
-                "country_criterion_id",
-            ]:
-                full_field_name = f"{resource_name}.{field_name}"
-                self.field_exclusions[full_field_name] = (
-                    resource_schema[resource_name]["fields"][full_field_name]["incompatible_fields"]
-                    or set()
-                )
-                self.schema[full_field_name] = {"type": ["null", "string"]}
-                self.behavior[full_field_name] = "ATTRIBUTE"
-
-
-class KeywordsPerformanceReport(ReportStream):
-    # TODO: The sync needs to select from ad_group_label if label.name is selected
-    # TODO: The sync needs to select from ad_group_label if label.resource_name is selected
-    def add_extra_fields(self, resource_schema):
-        for field_name in ["label.resource_name", "label.name"]:
-            self.field_exclusions[field_name] = set()
-            self.schema[field_name] = {"type": ["null", "string"]}
-            self.behavior[field_name] = "ATTRIBUTE"
-
-
-class PlaceholderFeedItemReport(ReportStream):
-    # TODO: The sync needs to select from feed_item_target if feed_item_target.device is selected
-    # TODO: The sync needs to select from feed_item if feed_item.policy_infos is selected
-    def add_extra_fields(self, resource_schema):
-        for field_name in ["feed_item_target.device", "feed_item.policy_infos"]:
-            self.field_exclusions[field_name] = set()
-            self.schema[field_name] = {"type": ["null", "string"]}
-            self.behavior[field_name] = "ATTRIBUTE"
-
-
 def initialize_core_streams(resource_schema):
     return {
         "accounts": BaseStream(
@@ -576,25 +468,12 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # TODO: This needs to link with ad_group_ad_label
-        # "adgroup_performance_report": AdGroupPerformanceReport(
-        #     report_definitions.ADGROUP_PERFORMANCE_REPORT_FIELDS,
-        #     ["ad_group"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "adgroup_performance_report": ReportStream(
             report_definitions.ADGROUP_PERFORMANCE_REPORT_FIELDS,
             ["ad_group"],
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # "ad_performance_report": AdPerformanceReport(
-        #     report_definitions.AD_PERFORMANCE_REPORT_FIELDS,
-        #     ["ad_group_ad"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "ad_performance_report": ReportStream(
             report_definitions.AD_PERFORMANCE_REPORT_FIELDS,
             ["ad_group_ad"],
@@ -607,12 +486,6 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # "audience_performance_report": AudiencePerformanceReport(
-        #     report_definitions.AUDIENCE_PERFORMANCE_REPORT_FIELDS,
-        #     ["campaign_audience_view", "ad_group_audience_view"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "audience_performance_report": ReportStream(
             report_definitions.AD_GROUP_AUDIENCE_PERFORMANCE_REPORT_FIELDS,
             ["ad_group_audience_view"],
@@ -631,24 +504,12 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # "display_keyword_performance_report": DisplayKeywordPerformanceReport(
-        #     report_definitions.DISPLAY_KEYWORD_PERFORMANCE_REPORT_FIELDS,
-        #     ["display_keyword_view"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "display_keyword_performance_report": ReportStream(
             report_definitions.DISPLAY_KEYWORD_PERFORMANCE_REPORT_FIELDS,
             ["display_keyword_view"],
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # "display_topics_performance_report": DisplayKeywordPerformanceReport(
-        #     report_definitions.DISPLAY_TOPICS_PERFORMANCE_REPORT_FIELDS,
-        #     ["topic_view"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "display_topics_performance_report": ReportStream(
             report_definitions.DISPLAY_TOPICS_PERFORMANCE_REPORT_FIELDS,
             ["topic_view"],
@@ -667,12 +528,6 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # "geo_performance_report": GeoPerformanceReport(
-        #     report_definitions.GEO_PERFORMANCE_REPORT_FIELDS,
-        #     ["geographic_view", "user_location_view"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "geo_performance_report": ReportStream(
             report_definitions.GEO_PERFORMANCE_REPORT_FIELDS,
             ["geographic_view"],
@@ -685,12 +540,6 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # "keywords_performance_report": KeywordsPerformanceReport(
-        #     report_definitions.KEYWORDS_PERFORMANCE_REPORT_FIELDS,
-        #     ["keyword_view"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "keywords_performance_report": ReportStream(
             report_definitions.KEYWORDS_PERFORMANCE_REPORT_FIELDS,
             ["keyword_view"],
@@ -703,12 +552,6 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        # "placeholder_feed_item_report": PlaceholderFeedItemReport(
-        #     report_definitions.PLACEHOLDER_FEED_ITEM_REPORT_FIELDS,
-        #     ["feed_item", "feed_item_target"],
-        #     resource_schema,
-        #     ["_sdc_record_hash"],
-        # ),
         "placeholder_feed_item_report": ReportStream(
             report_definitions.PLACEHOLDER_FEED_ITEM_REPORT_FIELDS,
             ["feed_item"],


### PR DESCRIPTION
# Description of change
This PR removes unused classes and comments in the `report_definitions.py` file related to supporting reports that need to query multiple resources.

The changes are added back in this branch: https://github.com/singer-io/tap-google-ads/tree/add-report-specific-classes
