### PR TITLE
v0.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
           at: /usr/local/share/virtualenvs
       - run:
           name: 'Run Integration Tests'
+          no_output_timeout: 30m
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-## v0.0.2
+## v0.1.0
   * Update bookmarks to only be written with a midnight time value
+  * Fix error logging to more concise
+  * Add retry logic to sync queries [#22](https://github.com/singer-io/tap-google-ads/pull/22)
+  * Fix field exclusion bug: Metrics can exclude attributes
+  * Rename:
+    * `adgroup_performance_report` to `ad_group_performance_report`
+    * `audience_performance_report` to `ad_group_audience_performance_report`
+  * Add `campaign_audience_performance_report`
 
 ## v0.0.1
   * Alpha Release [#13](https://github.com/singer-io/tap-google-ads/pull/13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.0.2
+  * Update bookmarks to only be written with a midnight time value
+
+## v0.0.1
+  * Alpha Release [#13](https://github.com/singer-io/tap-google-ads/pull/13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.1.0
+## v0.1.0 [#23](https://github.com/singer-io/tap-google-ads/pull/23)
   * Update bookmarks to only be written with a midnight time value
   * Fix error logging to more concise
   * Add retry logic to sync queries [#22](https://github.com/singer-io/tap-google-ads/pull/22)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='0.0.1',
+      version='0.1.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_google_ads/__init__.py
+++ b/tap_google_ads/__init__.py
@@ -6,6 +6,7 @@ from tap_google_ads.discover import create_resource_schema
 from tap_google_ads.discover import do_discover
 from tap_google_ads.sync import do_sync
 
+import logging
 
 LOGGER = singer.get_logger()
 
@@ -37,6 +38,9 @@ def main_impl():
 
 
 def main():
+
+    google_logger = logging.getLogger("google")
+    google_logger.setLevel(level=logging.CRITICAL)
 
     try:
         main_impl()

--- a/tap_google_ads/__init__.py
+++ b/tap_google_ads/__init__.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 import singer
 from singer import utils
-
 from tap_google_ads.discover import create_resource_schema
 from tap_google_ads.discover import do_discover
 from tap_google_ads.sync import do_sync
-
 import logging
 
 LOGGER = singer.get_logger()
+
 
 REQUIRED_CONFIG_KEYS = [
     "start_date",

--- a/tap_google_ads/__init__.py
+++ b/tap_google_ads/__init__.py
@@ -45,7 +45,6 @@ def main():
     try:
         main_impl()
     except Exception as e:
-        LOGGER.exception(e)
         for line in str(e).splitlines():
             LOGGER.critical(line)
         raise e

--- a/tap_google_ads/__init__.py
+++ b/tap_google_ads/__init__.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
+import logging
 import singer
 from singer import utils
 from tap_google_ads.discover import create_resource_schema
 from tap_google_ads.discover import do_discover
 from tap_google_ads.sync import do_sync
-import logging
+
 
 LOGGER = singer.get_logger()
 

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -194,24 +194,16 @@ def create_resource_schema(config):
         metrics_and_segments = set(metrics + segments)
 
         for field_name, field in fields.items():
-            if field["field_details"]["category"] == "ATTRIBUTE":
-                continue
             for compared_field in metrics_and_segments:
                 field_root_resource = get_root_resource_name(field_name)
                 compared_field_root_resource = get_root_resource_name(compared_field)
 
-                # Fields can be any of the categories in CATEGORY_MAP, but only METRIC & SEGMENT have exclusions, so only check those
                 if (
                     field_name != compared_field
                     and not compared_field.startswith(f"{field_root_resource}.")
                 ):
-
                     field_to_check = field_root_resource or field_name
                     compared_field_to_check = compared_field_root_resource or compared_field
-
-                    # Metrics will not be incompatible with other metrics, so don't check those
-                    if field_name.startswith("metrics.") and compared_field.startswith("metrics."):
-                        continue
 
                     # If a resource is selectable with another resource they should be in
                     # each other's 'selectable_with' list, but Google is missing some of

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -204,9 +204,6 @@ def create_resource_schema(config):
                 if (
                     field_name != compared_field
                     and not compared_field.startswith(f"{field_root_resource}.")
-                ) and (
-                    fields[compared_field]["field_details"]["category"] == "METRIC"
-                    or fields[compared_field]["field_details"]["category"] == "SEGMENT"
                 ):
 
                     field_to_check = field_root_resource or field_name

--- a/tap_google_ads/report_definitions.py
+++ b/tap_google_ads/report_definitions.py
@@ -793,7 +793,7 @@ DISPLAY_KEYWORD_PERFORMANCE_REPORT_FIELDS = [
     "ad_group_criterion.status",
     "ad_group_criterion.tracking_url_template",
     "ad_group_criterion.url_custom_parameters",
-    "bidding_strategy.name", # bidding_strategy.name must be selected with the resources bidding_strategy and campaign.
+    "bidding_strategy.name",
     "campaign.base_campaign",
     "campaign.bidding_strategy",
     "campaign.bidding_strategy_type",
@@ -882,7 +882,7 @@ DISPLAY_TOPICS_PERFORMANCE_REPORT_FIELDS = [
     "ad_group_criterion.topic.topic_constant",
     "ad_group_criterion.tracking_url_template",
     "ad_group_criterion.url_custom_parameters",
-    "bidding_strategy.name",  # bidding_strategy.name must be selected with the resources bidding_strategy and campaign.
+    "bidding_strategy.name",
     "campaign.base_campaign",
     "campaign.bidding_strategy",
     "campaign.bidding_strategy_type",

--- a/tap_google_ads/report_definitions.py
+++ b/tap_google_ads/report_definitions.py
@@ -78,7 +78,7 @@ ACCOUNT_PERFORMANCE_REPORT_FIELDS = [
     "segments.week",
     "segments.year",
 ]
-ADGROUP_PERFORMANCE_REPORT_FIELDS = [
+AD_GROUP_PERFORMANCE_REPORT_FIELDS = [
     "ad_group.ad_rotation_mode",
     "ad_group.base_ad_group",
     "ad_group.cpc_bid_micros",

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -94,6 +94,11 @@ retryable_errors = [
 
 
 def should_give_up(ex):
+    if isinstance(ex, AttributeError):
+        if str(ex) == "'NoneType' object has no attribute 'Call'":
+            return False
+        return True
+
     for googleads_error in ex.failure.errors:
         quota_error = str(googleads_error.error_code.quota_error)
         internal_error = str(googleads_error.error_code.internal_error)
@@ -110,7 +115,8 @@ def on_giveup_func(err):
 
 
 @backoff.on_exception(backoff.expo,
-                      GoogleAdsException,
+                      [GoogleAdsException,
+                       AttributeError],
                       max_tries=5,
                       jitter=None,
                       giveup=should_give_up,

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -276,7 +276,6 @@ class BaseStream:  # pylint: disable=too-many-instance-attributes
         stream_mdata = stream["metadata"]
         selected_fields = get_selected_fields(stream_mdata)
         state = singer.set_currently_syncing(state, stream_name)
-        LOGGER.info(f"Selected fields for stream {stream_name}: {selected_fields}")
 
         query = create_core_stream_query(resource_name, selected_fields)
         try:
@@ -441,7 +440,6 @@ class ReportStream(BaseStream):
             if query_date == cutoff:
                 LOGGER.info(f"Stream: {stream_name} supports only 90 days of data. Setting query date to {utils.strftime(query_date, '%Y-%m-%d')}.")
 
-        LOGGER.info(f"Selected fields for stream {stream_name}: {selected_fields}")
         singer.write_state(state)
 
         if selected_fields == {'segments.date'}:

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -461,7 +461,9 @@ class ReportStream(BaseStream):
                 response = make_request(gas, query, customer["customerId"])
             except GoogleAdsException as err:
                 LOGGER.warning("Failed query: %s", query)
-                raise err
+                LOGGER.critical(str(err.failure.errors[0].message))
+                raise RuntimeError from None
+
 
             with Transformer() as transformer:
                 # Pages are fetched automatically while iterating through the response

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -540,9 +540,15 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        "adgroup_performance_report": ReportStream(
-            report_definitions.ADGROUP_PERFORMANCE_REPORT_FIELDS,
+        "ad_group_performance_report": ReportStream(
+            report_definitions.AD_GROUP_PERFORMANCE_REPORT_FIELDS,
             ["ad_group"],
+            resource_schema,
+            ["_sdc_record_hash"],
+        ),
+        "ad_group_audience_performance_report": ReportStream(
+            report_definitions.AD_GROUP_AUDIENCE_PERFORMANCE_REPORT_FIELDS,
+            ["ad_group_audience_view"],
             resource_schema,
             ["_sdc_record_hash"],
         ),
@@ -558,15 +564,15 @@ def initialize_reports(resource_schema):
             resource_schema,
             ["_sdc_record_hash"],
         ),
-        "audience_performance_report": ReportStream(
-            report_definitions.AD_GROUP_AUDIENCE_PERFORMANCE_REPORT_FIELDS,
-            ["ad_group_audience_view"],
-            resource_schema,
-            ["_sdc_record_hash"],
-        ),
         "campaign_performance_report": ReportStream(
             report_definitions.CAMPAIGN_PERFORMANCE_REPORT_FIELDS,
             ["campaign"],
+            resource_schema,
+            ["_sdc_record_hash"],
+        ),
+        "campaign_audience_performance_report": ReportStream(
+            report_definitions.CAMPAIGN_AUDIENCE_PERFORMANCE_REPORT_FIELDS,
+            ["campaign_audience_view"],
             resource_schema,
             ["_sdc_record_hash"],
         ),

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -6,6 +6,8 @@ import singer
 from singer import Transformer
 from singer import utils
 from google.protobuf.json_format import MessageToJson
+from google.ads.googleads.errors import GoogleAdsException
+import backoff
 from . import report_definitions
 
 LOGGER = singer.get_logger()
@@ -80,6 +82,35 @@ def generate_hash(record, metadata):
     hash_source_data = {key: fields_to_hash[key] for key in sorted(fields_to_hash)}
     hash_bytes = json.dumps(hash_source_data).encode("utf-8")
     return hashlib.sha256(hash_bytes).hexdigest()
+
+
+retryable_errors = [
+    "QuotaError.RESOURCE_EXHAUSTED",
+    "QuotaError.RESOURCE_TEMPORARILY_EXHAUSTED",
+    "InternalError.INTERNAL_ERROR",
+    "InternalError.TRANSIENT_ERROR",
+    "InternalError.DEADLINE_EXCEEDED",
+]
+
+
+def should_give_up(ex):
+    for googleads_error in ex.failure.errors:
+        quota_error = str(googleads_error.error_code.quota_error)
+        internal_error = str(googleads_error.error_code.internal_error)
+        for err in [quota_error, internal_error]:
+            if err in retryable_errors:
+                return False
+    return True
+
+
+@backoff.on_exception(backoff.expo,
+                      GoogleAdsException,
+                      max_tries=5,
+                      jitter=None,
+                      giveup=should_give_up)
+def make_request(gas, query, customer_id):
+    response = gas.search(query=query, customer_id=customer_id)
+    return response
 
 
 class BaseStream:  # pylint: disable=too-many-instance-attributes
@@ -248,7 +279,12 @@ class BaseStream:  # pylint: disable=too-many-instance-attributes
         LOGGER.info(f"Selected fields for stream {stream_name}: {selected_fields}")
 
         query = create_core_stream_query(resource_name, selected_fields)
-        response = gas.search(query=query, customer_id=customer["customerId"])
+        try:
+            response = make_request(gas, query, customer["customerId"])
+        except GoogleAdsException as err:
+            LOGGER.warning("Failed query: %s", query)
+            raise err
+
         with Transformer() as transformer:
             # Pages are fetched automatically while iterating through the response
             for message in response:
@@ -414,7 +450,12 @@ class ReportStream(BaseStream):
         while query_date < end_date:
             query = create_report_query(resource_name, selected_fields, query_date)
             LOGGER.info(f"Requesting {stream_name} data for {utils.strftime(query_date, '%Y-%m-%d')}.")
-            response = gas.search(query=query, customer_id=customer["customerId"])
+
+            try:
+                response = make_request(gas, query, customer["customerId"])
+            except GoogleAdsException as err:
+                LOGGER.warning("Failed query: %s", query)
+                raise err
 
             with Transformer() as transformer:
                 # Pages are fetched automatically while iterating through the response

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -390,7 +390,7 @@ class ReportStream(BaseStream):
         conversion_window = timedelta(
             days=int(config.get("conversion_window") or DEFAULT_CONVERSION_WINDOW)
         )
-        conversion_window_date = utils.now() - conversion_window
+        conversion_window_date = utils.now().replace(hour=0, minute=0, second=0, microsecond=0) - conversion_window
 
         query_date = get_query_date(
             start_date=config["start_date"],
@@ -400,7 +400,7 @@ class ReportStream(BaseStream):
         end_date = utils.now()
 
         if stream_name in REPORTS_WITH_90_DAY_MAX:
-            cutoff = end_date - timedelta(days=90)
+            cutoff = end_date.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=90)
             query_date = max(query_date, cutoff)
             if query_date == cutoff:
                 LOGGER.info(f"Stream: {stream_name} supports only 90 days of data. Setting query date to {utils.strftime(query_date, '%Y-%m-%d')}.")

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -103,11 +103,19 @@ def should_give_up(ex):
     return True
 
 
+def on_giveup_func(err):
+    """This function lets us know that backoff ran, but it does not print
+    Google's verbose message and stack trace"""
+    LOGGER.warning("Giving up make_request after %s tries", err.get("tries"))
+
+
 @backoff.on_exception(backoff.expo,
                       GoogleAdsException,
                       max_tries=5,
                       jitter=None,
-                      giveup=should_give_up)
+                      giveup=should_give_up,
+                      on_giveup=on_giveup_func,
+                      logger=None)
 def make_request(gas, query, customer_id):
     response = gas.search(query=query, customer_id=customer_id)
     return response

--- a/tests/base.py
+++ b/tests/base.py
@@ -578,7 +578,7 @@ class GoogleAdsBase(unittest.TestCase):
                 'impressions',  # 'Impr.',
                 'view_through_conversions',  # 'View-through conv.',
             },
-            "adgroup_performance_report": {
+            "ad_group_performance_report": {
                 'average_cpc',  # Avg. CPC,
                 'clicks',  # Clicks,
                 'conversions',  # Conversions,
@@ -588,7 +588,7 @@ class GoogleAdsBase(unittest.TestCase):
                 'impressions',  # Impr.,
                 'view_through_conversions',  # View-through conv.,
             },
-            "audience_performance_report": {
+            "ad_group_audience_performance_report": {
                 'average_cpc',  # Avg. CPC,
                 'average_cpm',  # Avg. CPM
                 'clicks',  # Clicks,

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,7 +27,7 @@ class GoogleAdsBase(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
-    REPLICATION_KEY_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+    REPLICATION_KEY_FORMAT = "%Y-%m-%dT00:00:00.000000Z"
 
     start_date = ""
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,7 +27,7 @@ class GoogleAdsBase(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
-    REPLICATION_KEY_FORMAT = "%Y-%m-%dT00:00:00.000000Z"
+    REPLICATION_KEY_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     start_date = ""
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -138,6 +138,11 @@ class GoogleAdsBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date"},
             },
+            "campaign_audience_performance_report": {  # "campaign_audience_view"
+                self.PRIMARY_KEYS: {"_sdc_record_hash"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date"},
+            },
             # TODO Post Alpha
             # "call_metrics_call_details_report": {  # "call_view"
             #     self.PRIMARY_KEYS: {"_sdc_record_hash"},
@@ -234,7 +239,12 @@ class GoogleAdsBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date"},
             },
-            "adgroup_performance_report": {  # ad_group
+            "ad_group_performance_report": {  # ad_group
+                self.PRIMARY_KEYS: {"_sdc_record_hash"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date"},
+            },
+            "ad_group_audience_performance_report": {  # ad_group
                 self.PRIMARY_KEYS: {"_sdc_record_hash"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date"},

--- a/tests/base.py
+++ b/tests/base.py
@@ -128,12 +128,7 @@ class GoogleAdsBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date"},
             },
-            "audience_performance_report": {  # "campaign_audience_view"
-                self.PRIMARY_KEYS: {"_sdc_record_hash"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"date"},
-            },
-            "campaign_performance_report": {  # "campaign_audience_view"
+            "campaign_performance_report": {  # "campaign"
                 self.PRIMARY_KEYS: {"_sdc_record_hash"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date"},
@@ -244,7 +239,7 @@ class GoogleAdsBase(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date"},
             },
-            "ad_group_audience_performance_report": {  # ad_group
+            "ad_group_audience_performance_report": {  # ad_group_audience_view
                 self.PRIMARY_KEYS: {"_sdc_record_hash"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date"},

--- a/tests/test_google_ads_bookmarks.py
+++ b/tests/test_google_ads_bookmarks.py
@@ -57,6 +57,7 @@ class BookmarksTest(GoogleAdsBase):
             'shopping_performance_report',
             'user_location_performance_report',
             'video_performance_report',
+            'ad_group_audience_performance_report',
         }
 
         # Run a discovery job

--- a/tests/test_google_ads_bookmarks.py
+++ b/tests/test_google_ads_bookmarks.py
@@ -77,7 +77,7 @@ class BookmarksTest(GoogleAdsBase):
         self.select_all_streams_and_default_fields(conn_id, report_catalogs_1)
 
         # Run a sync
-        sync_job_name_1 = self.run_and_verify_sync(conn_id)
+        _ = self.run_and_verify_sync(conn_id)
 
         # acquire records from target output
         synced_records_1 = runner.get_records_from_target_output()
@@ -108,11 +108,7 @@ class BookmarksTest(GoogleAdsBase):
         menagerie.set_state(conn_id, manipulated_state)
 
         # Run another sync
-        sync_job_name_2 = self.run_and_verify_sync(conn_id)
-
-        # Verify the tap and target do not throw a critical error
-        exit_status_2 = menagerie.get_exit_status(conn_id, sync_job_name_2)
-        menagerie.verify_sync_exit_status(self, exit_status_2, sync_job_name_2)
+        _ = self.run_and_verify_sync(conn_id)
 
         # acquire records from target output
         synced_records_2 = runner.get_records_from_target_output()

--- a/tests/test_google_ads_bookmarks.py
+++ b/tests/test_google_ads_bookmarks.py
@@ -77,11 +77,7 @@ class BookmarksTest(GoogleAdsBase):
         self.select_all_streams_and_default_fields(conn_id, report_catalogs_1)
 
         # Run a sync
-        sync_job_name_1 = runner.run_sync_mode(self, conn_id)
-
-        # Verify the tap and target do not throw a critical error
-        exit_status_1 = menagerie.get_exit_status(conn_id, sync_job_name_1)
-        menagerie.verify_sync_exit_status(self, exit_status_1, sync_job_name_1)
+        sync_job_name_1 = self.run_and_verify_sync(conn_id)
 
         # acquire records from target output
         synced_records_1 = runner.get_records_from_target_output()
@@ -112,7 +108,7 @@ class BookmarksTest(GoogleAdsBase):
         menagerie.set_state(conn_id, manipulated_state)
 
         # Run another sync
-        sync_job_name_2 = runner.run_sync_mode(self, conn_id)
+        sync_job_name_2 = self.run_and_verify_sync(conn_id)
 
         # Verify the tap and target do not throw a critical error
         exit_status_2 = menagerie.get_exit_status(conn_id, sync_job_name_2)
@@ -193,7 +189,7 @@ class BookmarksTest(GoogleAdsBase):
                     # Verify the bookmark is set based on sync execution time for sync 2
                     # (The tap replicaates from the manipulated state through to todayf)
                     parsed_bookmark_value_2 = dt.strptime(bookmark_value_2, self.REPLICATION_KEY_FORMAT)
-                    self.assertEqual(parsed_bookmark_value_1, today_datetime)
+                    self.assertEqual(parsed_bookmark_value_2, today_datetime)
 
                     # Verify 2nd sync only replicates records newer than manipulated_state_formatted
                     for record in records_2:

--- a/tests/test_google_ads_bookmarks.py
+++ b/tests/test_google_ads_bookmarks.py
@@ -45,7 +45,7 @@ class BookmarksTest(GoogleAdsBase):
         conn_id = connections.ensure_connection(self)
 
         streams_under_test = self.expected_streams() - {
-            'audience_performance_report',
+            'ad_group_audience_performance_report',
             'display_keyword_performance_report',
             'display_topics_performance_report',
             'expanded_landing_page_report',
@@ -57,7 +57,7 @@ class BookmarksTest(GoogleAdsBase):
             'shopping_performance_report',
             'user_location_performance_report',
             'video_performance_report',
-            'ad_group_audience_performance_report',
+            'campaign_audience_performance_report',
         }
 
         # Run a discovery job
@@ -90,7 +90,7 @@ class BookmarksTest(GoogleAdsBase):
         data_set_state_value_1 = '2022-01-24T00:00:00.000000Z'
         data_set_state_value_2 = '2021-12-30T00:00:00.000000Z'
         injected_state_by_stream = {
-            'adgroup_performance_report':data_set_state_value_1,
+            'ad_group_performance_report':data_set_state_value_1,
             'geo_performance_report':data_set_state_value_1,
             'gender_performance_report':data_set_state_value_1,
             'placeholder_feed_item_report':data_set_state_value_2,

--- a/tests/test_google_ads_bookmarks.py
+++ b/tests/test_google_ads_bookmarks.py
@@ -15,15 +15,36 @@ class BookmarksTest(GoogleAdsBase):
     def name():
         return "tt_google_ads_bookmarks"
 
+    def assertIsDateFormat(self, value, str_format):
+        """
+        Assertion Method that verifies a string value is a formatted datetime with
+        the specified format.
+        """
+        try:
+            _ = dt.strptime(value, str_format)
+        except ValueError as err:
+            raise AssertionError(
+                f"Value does not conform to expected format: {str_format}"
+            ) from err
+
+
     def test_run(self):
         """
-        Testing that the tap sets and uses bookmarks correctly
+        Testing that the tap sets and uses bookmarks correctly where
+        state < (today - converstion window), therefore the state should be used
+        on sync 2
+
+        Outstanding Work:
+          TODO_TDL-17918 Determine if we can test the following case at the tap-tester level
+          A sync results in a state such that state > (today - converstion window), therfore the
+          tap should pick up based on (today - converstion window) on sync 2.
+
         """
         print("Bookmarks Test for tap-google-ads")
 
         conn_id = connections.ensure_connection(self)
 
-        streams_to_test = self.expected_streams() - {
+        streams_under_test = self.expected_streams() - {
             'audience_performance_report',
             'display_keyword_performance_report',
             'display_topics_performance_report',
@@ -43,7 +64,7 @@ class BookmarksTest(GoogleAdsBase):
 
         # partition catalogs for use in table/field seelction
         test_catalogs_1 = [catalog for catalog in found_catalogs_1
-                           if catalog.get('stream_name') in streams_to_test]
+                           if catalog.get('stream_name') in streams_under_test]
         core_catalogs_1 = [catalog for catalog in test_catalogs_1
                            if not self.is_report(catalog['stream_name'])]
         report_catalogs_1 = [catalog for catalog in test_catalogs_1
@@ -68,22 +89,26 @@ class BookmarksTest(GoogleAdsBase):
         bookmarks_1 = state_1.get('bookmarks')
         currently_syncing_1 = state_1.get('currently_syncing', 'KEY NOT SAVED IN STATE')
 
-        # TODO_TDL-17918 Determine if we can test all cases at the tap-tester level
-        # TEST CASE 1: state > today - converstion window, time format 2.  Will age out and become TC2 Feb 24, 22
-        # TEST CASE 2: state < today - converstion window, time format 1
-        manipulated_state = {'currently_syncing': 'None',
-                             'bookmarks': {
-                                 'adgroup_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                                 'geo_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                                 'gender_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                                 'placeholder_feed_item_report': {'date': '2021-12-30T00:00:00.000000Z'},
-                                 'age_range_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                                 'account_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                                 'click_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                                 'campaign_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                                 'placeholder_report': {'date': '2021-12-30T00:00:00.000000Z'},
-                                 'ad_performance_report': {'date': '2022-01-24T00:00:00.000000Z'},
-                             }}
+        # inject a simulated state value for each report stream under test
+        data_set_state_value_1 = '2022-01-24T00:00:00.000000Z'
+        data_set_state_value_2 = '2021-12-30T00:00:00.000000Z'
+        injected_state_by_stream = {
+            'adgroup_performance_report':data_set_state_value_1,
+            'geo_performance_report':data_set_state_value_1,
+            'gender_performance_report':data_set_state_value_1,
+            'placeholder_feed_item_report':data_set_state_value_2,
+            'age_range_performance_report':data_set_state_value_1,
+            'account_performance_report':data_set_state_value_1,
+            'click_performance_report':data_set_state_value_1,
+            'campaign_performance_report':data_set_state_value_1,
+            'placeholder_report':data_set_state_value_2,
+            'ad_performance_report':data_set_state_value_1,
+        }
+        manipulated_state = {
+            'currently_syncing': 'None',
+            'bookmarks': {stream: {'date': injected_state_by_stream[stream]}
+                          for stream in streams_under_test if self.is_report(stream)}
+        }
         menagerie.set_state(conn_id, manipulated_state)
 
         # Run another sync
@@ -112,21 +137,25 @@ class BookmarksTest(GoogleAdsBase):
             # Verify bookmarks are saved
             self.assertIsNotNone(bookmarks_2)
 
-            # Verify ONLY report streams under test have bookmark entries in state
-            expected_incremental_streams = {stream for stream in streams_to_test if self.is_report(stream)}
-            unexpected_incremental_streams_1 = {stream for stream in bookmarks_1.keys() if stream not in expected_incremental_streams}
-            unexpected_incremental_streams_2 = {stream for stream in bookmarks_2.keys() if stream not in expected_incremental_streams}
+            # Verify ONLY report streams under test have bookmark entries in state for sync 1
+            expected_incremental_streams = {stream for stream in streams_under_test if self.is_report(stream)}
+            unexpected_incremental_streams_1 = {stream for stream in bookmarks_1.keys()
+                                                if stream not in expected_incremental_streams}
             self.assertSetEqual(set(), unexpected_incremental_streams_1)
+
+            # Verify ONLY report streams under test have bookmark entries in state for sync 2
+            unexpected_incremental_streams_2 = {stream for stream in bookmarks_2.keys()
+                                                if stream not in expected_incremental_streams}
             self.assertSetEqual(set(), unexpected_incremental_streams_2)
 
         # stream-level assertions
-        for stream in streams_to_test:
+        for stream in streams_under_test:
             with self.subTest(stream=stream):
 
                 # set expectations
                 expected_replication_method = self.expected_replication_method()[stream]
                 conversion_window = timedelta(days=30) # defaulted value
-
+                today_datetime = dt.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
                 # gather results
                 records_1 = [message['data'] for message in synced_records_1[stream]['messages']]
                 records_2 = [message['data'] for message in synced_records_2[stream]['messages']]
@@ -137,71 +166,48 @@ class BookmarksTest(GoogleAdsBase):
 
                 if expected_replication_method == self.INCREMENTAL:
 
-                    # included to catch a contradiction in our base expectations
-                    if not self.is_report(stream):
-                        raise AssertionError(
-                            f"Only Reports streams should be expected to support {expected_replication_method} replication."
-                        )
-
+                    # gather expectations
                     expected_replication_key = list(self.expected_replication_keys()[stream])[0]  # assumes 1 value
                     manipulated_bookmark = manipulated_state['bookmarks'][stream]
-                    today_minus_conversion_window = dt.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - conversion_window
-                    today = dt.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
                     manipulated_state_formatted = dt.strptime(manipulated_bookmark.get(expected_replication_key), self.REPLICATION_KEY_FORMAT)
-                    if manipulated_state_formatted < today_minus_conversion_window:
-                        reference_time = manipulated_state_formatted
-                    else:
-                        reference_time = today_minus_conversion_window
 
                     # Verify bookmarks saved match formatting standards for sync 1
                     self.assertIsNotNone(stream_bookmark_1)
                     bookmark_value_1 = stream_bookmark_1.get(expected_replication_key)
                     self.assertIsNotNone(bookmark_value_1)
                     self.assertIsInstance(bookmark_value_1, str)
-                    try:
-                        parsed_bookmark_value_1 = dt.strptime(bookmark_value_1, self.REPLICATION_KEY_FORMAT)
-                    except ValueError as err:
-                        raise AssertionError(
-                            f"Bookmarked value does not conform to expected format: {self.REPLICATION_KEY_FORMAT}"
-                        ) from err
+                    self.assertIsDateFormat(bookmark_value_1, self.REPLICATION_KEY_FORMAT)
 
                     # Verify bookmarks saved match formatting standards for sync 2
                     self.assertIsNotNone(stream_bookmark_2)
                     bookmark_value_2 = stream_bookmark_2.get(expected_replication_key)
                     self.assertIsNotNone(bookmark_value_2)
                     self.assertIsInstance(bookmark_value_2, str)
+                    self.assertIsDateFormat(bookmark_value_2, self.REPLICATION_KEY_FORMAT)
 
-                    try:
-                        parsed_bookmark_value_2 = dt.strptime(bookmark_value_2, self.REPLICATION_KEY_FORMAT)
-                    except ValueError as err:
+                    # Verify the bookmark is set based on sync end date (today) for sync 1
+                    # (The tap replicaates from the start date through to today)
+                    parsed_bookmark_value_1 = dt.strptime(bookmark_value_1, self.REPLICATION_KEY_FORMAT)
+                    self.assertEqual(parsed_bookmark_value_1, today_datetime)
 
-                        try:
-                            parsed_bookmark_value_2 = dt.strptime(bookmark_value_2, "%Y-%m-%dT%H:%M:%S.%fZ")
-                        except ValueError as err:
+                    # Verify the bookmark is set based on sync execution time for sync 2
+                    # (The tap replicaates from the manipulated state through to todayf)
+                    parsed_bookmark_value_2 = dt.strptime(bookmark_value_2, self.REPLICATION_KEY_FORMAT)
+                    self.assertEqual(parsed_bookmark_value_1, today_datetime)
 
-                            raise AssertionError(
-                                f"Bookmarked value does not conform to expected formats: " +
-                                "\n Format 1: {}".format(self.REPLICATION_KEY_FORMAT) +
-                                "\n Format 2: %Y-%m-%dT%H:%M:%S.%fZ"
-                            ) from err
-
-                    # Verify the bookmark is set based on sync execution time
-                    self.assertGreaterEqual(parsed_bookmark_value_1, today) # TODO can we get more sepecifc with this?
-                    self.assertGreaterEqual(parsed_bookmark_value_2, today)
-
-                    # Verify 2nd sync only replicates records newer than reference_time
+                    # Verify 2nd sync only replicates records newer than manipulated_state_formatted
                     for record in records_2:
                         rec_time = dt.strptime(record.get(expected_replication_key), self.REPLICATION_KEY_FORMAT)
-                        self.assertGreaterEqual(rec_time, reference_time, \
-                            msg="record time cannot be less than reference time: {}".format(reference_time)
+                        self.assertGreaterEqual(rec_time, manipulated_state_formatted, \
+                            msg="record time cannot be less than reference time: {}".format(manipulated_state_formatted)
                         )
 
-                    # Verify  the number of records in records_1 where sync >= reference_time
+                    # Verify  the number of records in records_1 where sync >= manipulated_state_formatted
                     # matches the number of records in records_2
                     records_1_after_manipulated_bookmark = 0
                     for record in records_1:
                         rec_time = dt.strptime(record.get(expected_replication_key), self.REPLICATION_KEY_FORMAT)
-                        if rec_time >= reference_time:
+                        if rec_time >= manipulated_state_formatted:
                             records_1_after_manipulated_bookmark += 1
                     self.assertEqual(records_1_after_manipulated_bookmark, record_count_2, \
                                      msg="Expected {} records in each sync".format(records_1_after_manipulated_bookmark))

--- a/tests/test_google_ads_discovery.py
+++ b/tests/test_google_ads_discovery.py
@@ -189,9 +189,9 @@ class DiscoveryTest(GoogleAdsBase):
             # Report objects
             "age_range_performance_report": {  # "age_range_view"
             },
-            "audience_performance_report": {  # "campaign_audience_view"
+            "ad_group_audience_performance_report": {  # "ad_group_audience_view"
             },
-            "campaign_performance_report": {  # "campaign_audience_view"
+            "campaign_performance_report": {  # "campaign"
             },
             "call_metrics_call_details_report": {  # "call_view"
             },
@@ -227,7 +227,7 @@ class DiscoveryTest(GoogleAdsBase):
             },
             "account_performance_report": { # accounts
             },
-            "adgroup_performance_report": {  # ad_group
+            "ad_group_performance_report": {  # ad_group
             },
             "ad_performance_report": {  # ads
             },

--- a/tests/test_google_ads_start_date.py
+++ b/tests/test_google_ads_start_date.py
@@ -159,6 +159,7 @@ class StartDateTest1(StartDateTest):
         'landing_page_report',
         'expanded_landing_page_report',
         'user_location_performance_report',
+        'ad_group_audience_performance_report',
     }
 
     def setUp(self):

--- a/tests/test_google_ads_start_date.py
+++ b/tests/test_google_ads_start_date.py
@@ -154,12 +154,12 @@ class StartDateTest1(StartDateTest):
         "keywords_performance_report",  # no test data available
         "keywordless_query_report",  # no test data available
         "video_performance_report",  # no test data available
-        'audience_performance_report',
+        'ad_group_audience_performance_report',
         "shopping_performance_report",
         'landing_page_report',
         'expanded_landing_page_report',
         'user_location_performance_report',
-        'ad_group_audience_performance_report',
+        'campaign_audience_performance_report',
     }
 
     def setUp(self):

--- a/tests/test_google_ads_sync_canary.py
+++ b/tests/test_google_ads_sync_canary.py
@@ -59,7 +59,7 @@ class DiscoveryTest(GoogleAdsBase):
                 # 'long_headline',  # 'Long headline',
                 'view_through_conversions',  # 'View-through conv.',
             },
-            "adgroup_performance_report": {
+            "ad_group_performance_report": {
                 # 'account_name',  # Account name,
                 # 'ad_group',  # Ad group,
                 # 'ad_group_state',  # Ad group state,
@@ -79,7 +79,7 @@ class DiscoveryTest(GoogleAdsBase):
                 'view_through_conversions',  # View-through conv.,
             },
             # TODO_TDL-17909 | [BUG?] missing audience fields
-            "audience_performance_report": {
+            "ad_group_audience_performance_report": {
                 # 'account_name', # Account name,
                 # 'ad_group_name', # 'ad_group',  # Ad group,
                 # 'ad_group_default_max_cpc',  # Ad group default max. CPC,
@@ -313,7 +313,7 @@ class DiscoveryTest(GoogleAdsBase):
             # TODO_TDL-17885 the following are not yet implemented
             'display_keyword_performance_report', # no test data available
             'display_topics_performance_report',  # no test data available
-            'audience_performance_report',  # Potential BUG see above
+            'ad_group_audience_performance_report',  # Potential BUG see above
             'placement_performance_report',  # no test data available
             "keywords_performance_report",  # no test data available
             "keywordless_query_report",  # no test data available
@@ -322,7 +322,6 @@ class DiscoveryTest(GoogleAdsBase):
             "user_location_performance_report",  # no test data available
             'landing_page_report',  # not attempted 
             'expanded_landing_page_report', # not attempted
-            'ad_group_audience_performance_report',
         }
 
         # Run a discovery job

--- a/tests/test_google_ads_sync_canary.py
+++ b/tests/test_google_ads_sync_canary.py
@@ -322,6 +322,7 @@ class DiscoveryTest(GoogleAdsBase):
             "user_location_performance_report",  # no test data available
             'landing_page_report',  # not attempted 
             'expanded_landing_page_report', # not attempted
+            'campaign_audience_performance_report', # not attempted
         }
 
         # Run a discovery job

--- a/tests/test_google_ads_sync_canary.py
+++ b/tests/test_google_ads_sync_canary.py
@@ -1,4 +1,3 @@
-"""Test tap discovery mode and metadata."""
 import re
 
 from tap_tester import menagerie, connections, runner
@@ -6,7 +5,7 @@ from tap_tester import menagerie, connections, runner
 from base import GoogleAdsBase
 
 
-class DiscoveryTest(GoogleAdsBase):
+class SyncCanaryTest(GoogleAdsBase):
     """
     Test tap's sync mode can extract records for all streams
     with standard table and field selection.

--- a/tests/test_google_ads_sync_canary.py
+++ b/tests/test_google_ads_sync_canary.py
@@ -321,7 +321,8 @@ class DiscoveryTest(GoogleAdsBase):
             "video_performance_report",  # no test data available
             "user_location_performance_report",  # no test data available
             'landing_page_report',  # not attempted 
-            'expanded_landing_page_report', # not attempted 
+            'expanded_landing_page_report', # not attempted
+            'ad_group_audience_performance_report',
         }
 
         # Run a discovery job


### PR DESCRIPTION
# Description of change
FUNCTIONAL:
  * Update bookmarks to only be written with a midnight time value
  * Fix error logging to more concise
  * Add retry logic to sync queries [#22](https://github.com/singer-io/tap-google-ads/pull/22)
  * Fix field exclusion bug: Metrics can exclude attributes
  * Rename:
    * `adgroup_performance_report` to `ad_group_performance_report`
    * `audience_performance_report` to `ad_group_audience_performance_report`
  * Add `campaign_audience_performance_report`

QA:
  * Fix and cleanup Bookmarks test
  * Increase no-output timeout
  * Address feedback in PR
  * Add Retry Unit Tests
  * Update tests for stream renames where applicable.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
  - Ran discovery and validated functionality in local UI.
 
# Risks
- Minimal; alpha integration

# Rollback steps
 - revert this branch
