### PR TITLE
Add currently syncing

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -96,6 +96,7 @@ retryable_errors = [
 def should_give_up(ex):
     if isinstance(ex, AttributeError):
         if str(ex) == "'NoneType' object has no attribute 'Call'":
+            LOGGER.info('Retrying request due to AttributeError')
             return False
         return True
 
@@ -104,6 +105,7 @@ def should_give_up(ex):
         internal_error = str(googleads_error.error_code.internal_error)
         for err in [quota_error, internal_error]:
             if err in retryable_errors:
+                LOGGER.info(f'Retrying request due to {err}')
                 return False
     return True
 

--- a/tap_google_ads/sync.py
+++ b/tap_google_ads/sync.py
@@ -25,15 +25,15 @@ def do_sync(config, catalog, resource_schema, state):
     core_streams = initialize_core_streams(resource_schema)
     report_streams = initialize_reports(resource_schema)
 
-    for customer in customers:
-        LOGGER.info(f"Syncing customer Id {customer['customerId']} ...")
-        sdk_client = create_sdk_client(config, customer["loginCustomerId"])
-        for catalog_entry in selected_streams:
-            stream_name = catalog_entry["stream"]
-            mdata_map = singer.metadata.to_map(catalog_entry["metadata"])
+    for catalog_entry in selected_streams:
+        stream_name = catalog_entry["stream"]
+        mdata_map = singer.metadata.to_map(catalog_entry["metadata"])
 
-            primary_key = mdata_map[()].get("table-key-properties", [])
-            singer.messages.write_schema(stream_name, catalog_entry["schema"], primary_key)
+        primary_key = mdata_map[()].get("table-key-properties", [])
+        singer.messages.write_schema(stream_name, catalog_entry["schema"], primary_key)
+
+        for customer in customers:
+            sdk_client = create_sdk_client(config, customer["loginCustomerId"])
 
             LOGGER.info(f"Syncing {stream_name} for customer Id {customer['customerId']}.")
 

--- a/tap_google_ads/sync.py
+++ b/tap_google_ads/sync.py
@@ -9,7 +9,7 @@ LOGGER = singer.get_logger()
 
 
 def get_currently_syncing(state):
-    resuming_stream, resuming_customer = state.get("currently_syncing")
+    resuming_stream, resuming_customer = state.get("currently_syncing", (None, None))
     return resuming_stream, resuming_customer
 
 

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -2,6 +2,7 @@ import unittest
 from tap_google_ads.streams import generate_hash
 from tap_google_ads.streams import get_query_date
 from tap_google_ads.streams import create_nested_resource_schema
+from tap_google_ads.sync import shuffle
 from singer import metadata
 from singer.utils import strptime_to_utc
 
@@ -211,6 +212,94 @@ class TestGetQueryDate(unittest.TestCase):
         )
         expected = strptime_to_utc("2022-01-14T00:00:00Z")
         self.assertEqual(expected, actual)
+
+
+class TestShuffleStreams(unittest.TestCase):
+    selected_streams = [
+        {"tap_stream_id": "stream1"},
+        {"tap_stream_id": "stream2"},
+        {"tap_stream_id": "stream3"},
+        {"tap_stream_id": "stream4"},
+        {"tap_stream_id": "stream5"},
+    ]
+
+    def test_shuffle_first_stream(self):
+        actual = shuffle(self.selected_streams, "tap_stream_id", "stream1")
+        expected = [
+            {"tap_stream_id": "stream1"},
+            {"tap_stream_id": "stream2"},
+            {"tap_stream_id": "stream3"},
+            {"tap_stream_id": "stream4"},
+            {"tap_stream_id": "stream5"},
+        ]
+        self.assertListEqual(expected, actual)
+
+
+    def test_shuffle_middle_stream(self):
+        actual = shuffle(self.selected_streams, "tap_stream_id", "stream3")
+        expected = [
+            {"tap_stream_id": "stream3"},
+            {"tap_stream_id": "stream4"},
+            {"tap_stream_id": "stream5"},
+            {"tap_stream_id": "stream1"},
+            {"tap_stream_id": "stream2"},
+        ]
+        self.assertListEqual(expected, actual)
+
+    def test_shuffle_last_stream(self):
+        actual = shuffle(self.selected_streams, "tap_stream_id", "stream5")
+        expected = [
+            {"tap_stream_id": "stream5"},
+            {"tap_stream_id": "stream1"},
+            {"tap_stream_id": "stream2"},
+            {"tap_stream_id": "stream3"},
+            {"tap_stream_id": "stream4"},
+        ]
+        self.assertListEqual(expected, actual)
+
+
+class TestShuffleCustomers(unittest.TestCase):
+
+    customers = [
+        {"customerId": "customer1"},
+        {"customerId": "customer2"},
+        {"customerId": "customer3"},
+        {"customerId": "customer4"},
+        {"customerId": "customer5"},
+    ]
+
+    def test_shuffle_first_customer(self):
+        actual = shuffle(self.customers, "customerId", "customer1")
+        expected = [
+            {"customerId": "customer1"},
+            {"customerId": "customer2"},
+            {"customerId": "customer3"},
+            {"customerId": "customer4"},
+            {"customerId": "customer5"},
+        ]
+        self.assertListEqual(expected, actual)
+
+    def test_shuffle_middle_customer(self):
+        actual = shuffle(self.customers, "customerId", "customer3")
+        expected = [
+            {"customerId": "customer3"},
+            {"customerId": "customer4"},
+            {"customerId": "customer5"},
+            {"customerId": "customer1"},
+            {"customerId": "customer2"},
+        ]
+        self.assertListEqual(expected, actual)
+
+    def test_shuffle_last_customer(self):
+        actual = shuffle(self.customers, "customerId", "customer5")
+        expected = [
+            {"customerId": "customer5"},
+            {"customerId": "customer1"},
+            {"customerId": "customer2"},
+            {"customerId": "customer3"},
+            {"customerId": "customer4"},
+        ]
+        self.assertListEqual(expected, actual)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description of change
* Implements proper use of currently_syncing.
* Adds customerId to state for each stream.
* Reorders sync hierarchy to iterate over each customer for each stream.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
  - [ ] Tests passing locally.
  - [X] Added unit tests for currently_syncing shuffle
 
# Risks
Minimal; tap is in alpha.

# Rollback steps
 - revert this branch
