### PR TITLE
Add end date

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -455,7 +455,12 @@ class ReportStream(BaseStream):
             bookmark=bookmark_value,
             conversion_window_date=singer.utils.strftime(conversion_window_date)
         )
-        end_date = utils.now()
+
+        end_date = config.get("end_date")
+        if end_date:
+            end_date = utils.strptime_to_utc(end_date)
+        else:
+            end_date = utils.now()
 
         if stream_name in REPORTS_WITH_90_DAY_MAX:
             cutoff = end_date.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=90)
@@ -466,7 +471,7 @@ class ReportStream(BaseStream):
         if selected_fields == {'segments.date'}:
             raise Exception(f"Selected fields is currently limited to {', '.join(selected_fields)}. Please select at least one attribute and metric in order to replicate {stream_name}.")
 
-        while query_date < end_date:
+        while query_date <= end_date:
             query = create_report_query(resource_name, selected_fields, query_date)
             LOGGER.info(f"Requesting {stream_name} data for {utils.strftime(query_date, '%Y-%m-%d')}.")
 

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,87 @@
+import unittest
+from datetime import datetime
+from datetime import timedelta
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+from tap_google_ads.streams import ReportStream
+from tap_google_ads.streams import make_request
+
+
+resource_schema = {
+    "accessible_bidding_strategy": {
+        "fields": {}
+    },
+
+}
+
+class TestEndDate(unittest.TestCase):
+
+    def run_test(self, start_date, end_date, fake_make_request):
+
+        # Create the stream so we can call sync
+        my_report_stream = ReportStream(
+            fields=[],
+            google_ads_resource_names=['accessible_bidding_strategy'],
+            resource_schema=resource_schema,
+            primary_keys=['foo']
+        )
+
+        # Create a config that maybe has an end date
+        config = {"start_date": str(start_date),}
+
+        if end_date:
+            config["end_date"] = str(end_date)
+        else:
+            end_date = datetime.now()
+
+        my_report_stream.sync(
+            Mock(),
+            {"customerId": "123",
+             "loginCustomerId": "456"},
+            {"tap_stream_id": "hi",
+             "stream": "hi",
+             "metadata": []},
+            config,
+            {}
+        )
+
+        all_queries_requested = []
+        for request_sent in fake_make_request.call_args_list:
+            # The function signature is gas, query, customer_id
+            _, query, _ = request_sent.args
+            all_queries_requested.append(query)
+
+        delta_days = end_date - start_date
+        expected_days = [start_date]
+        for i in range(delta_days.days):
+            expected_days.append(
+                start_date + timedelta(days=1)
+            )
+
+
+        for day in expected_days:
+            # YYYY-MM-DD
+            date_portion = str(day)[:10]
+
+            self.assertTrue(
+                any(
+                    date_portion in query for query in all_queries_requested
+                )
+            )
+
+
+    @patch('tap_google_ads.streams.make_request')
+    def test_no_end_date(self, fake_make_request):
+        start_date = datetime(2022, 1, 1, 0, 0, 0)
+        end_date = None
+        self.run_test(start_date, end_date, fake_make_request)
+
+    @patch('tap_google_ads.streams.make_request')
+    def test_end_date_one_day_after_start(self, fake_make_request):
+        start_date = datetime(2022, 3, 5, 0, 0, 0)
+        end_date = datetime(2022, 3, 6, 0, 0, 0)
+        self.run_test(start_date, end_date, fake_make_request)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -6,7 +6,8 @@ from unittest.mock import Mock
 from unittest.mock import patch
 from tap_google_ads.streams import ReportStream
 from tap_google_ads.streams import make_request
-
+import singer
+import pytz
 
 resource_schema = {
     "accessible_bidding_strategy": {
@@ -53,10 +54,17 @@ class TestEndDate(unittest.TestCase):
             {}
         )
 
+    @patch('singer.utils.now')
     @patch('tap_google_ads.streams.make_request')
-    def test_no_end_date(self, fake_make_request):
+    def test_no_end_date(self, fake_make_request, fake_datetime_now):
         start_date = datetime(2022, 1, 1, 0, 0, 0)
-        end_date = datetime.now()
+        end_date = datetime(2022, 3, 1, 0, 0, 0)
+
+        # Adding tzinfo helped the mock to work and avoids a
+        # TypeError(can't subtract offset-naive and offset-aware
+        # datetimes) here in the test
+        fake_datetime_now.return_value = end_date.replace(tzinfo=pytz.UTC)
+
         # Don't pass in end_date to test the tap's fallback to today
         self.run_sync(start_date, None, fake_make_request)
         all_queries_requested = self.get_queries_from_sync(fake_make_request)
@@ -67,11 +75,23 @@ class TestEndDate(unittest.TestCase):
         days_between_start_and_end = date_delta.days + 1
 
         # Compute the range of expected days, because end_date will always shift
-        expected_days = []
-        for i in range(days_between_start_and_end):
-            expected_datetime = start_date + timedelta(days=i)
-            expected_day = str(expected_datetime)[:10]
-            expected_days.append(expected_day)
+        expected_days = [
+            '2022-01-01', '2022-01-02', '2022-01-03', '2022-01-04',
+            '2022-01-05', '2022-01-06', '2022-01-07', '2022-01-08',
+            '2022-01-09', '2022-01-10', '2022-01-11', '2022-01-12',
+            '2022-01-13', '2022-01-14', '2022-01-15', '2022-01-16',
+            '2022-01-17', '2022-01-18', '2022-01-19', '2022-01-20',
+            '2022-01-21', '2022-01-22', '2022-01-23', '2022-01-24',
+            '2022-01-25', '2022-01-26', '2022-01-27', '2022-01-28',
+            '2022-01-29', '2022-01-30', '2022-01-31', '2022-02-01',
+            '2022-02-02', '2022-02-03', '2022-02-04', '2022-02-05',
+            '2022-02-06', '2022-02-07', '2022-02-08', '2022-02-09',
+            '2022-02-10', '2022-02-11', '2022-02-12', '2022-02-13',
+            '2022-02-14', '2022-02-15', '2022-02-16', '2022-02-17',
+            '2022-02-18', '2022-02-19', '2022-02-20', '2022-02-21',
+            '2022-02-22', '2022-02-23', '2022-02-24', '2022-02-25',
+            '2022-02-26', '2022-02-27', '2022-02-28', '2022-03-01',
+        ]
 
         for day in expected_days:
             self.assertTrue(

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -17,6 +17,14 @@ resource_schema = {
 
 class TestEndDate(unittest.TestCase):
 
+    def get_queries_from_sync(self, fake_make_request):
+        all_queries_requested = []
+        for request_sent in fake_make_request.call_args_list:
+            # The function signature is gas, query, customer_id
+            _, query, _ = request_sent.args
+            all_queries_requested.append(query)
+        return all_queries_requested
+
     def run_sync(self, start_date, end_date, fake_make_request):
 
         # Create the stream so we can call sync
@@ -46,11 +54,6 @@ class TestEndDate(unittest.TestCase):
             {}
         )
 
-        all_queries_requested = []
-        for request_sent in fake_make_request.call_args_list:
-            # The function signature is gas, query, customer_id
-            _, query, _ = request_sent.args
-            all_queries_requested.append(query)
 
         delta_days = end_date - start_date
         expected_days = [start_date]

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -17,7 +17,7 @@ resource_schema = {
 
 class TestEndDate(unittest.TestCase):
 
-    def do_thing(self, start_date, end_date, fake_make_request):
+    def run_sync(self, start_date, end_date, fake_make_request):
 
         # Create the stream so we can call sync
         my_report_stream = ReportStream(

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -17,7 +17,7 @@ resource_schema = {
 
 class TestEndDate(unittest.TestCase):
 
-    def run_test(self, start_date, end_date, fake_make_request):
+    def do_thing(self, start_date, end_date, fake_make_request):
 
         # Create the stream so we can call sync
         my_report_stream = ReportStream(
@@ -75,13 +75,13 @@ class TestEndDate(unittest.TestCase):
     def test_no_end_date(self, fake_make_request):
         start_date = datetime(2022, 1, 1, 0, 0, 0)
         end_date = None
-        self.run_test(start_date, end_date, fake_make_request)
+        self.do_thing(start_date, end_date, fake_make_request)
 
     @patch('tap_google_ads.streams.make_request')
     def test_end_date_one_day_after_start(self, fake_make_request):
         start_date = datetime(2022, 3, 5, 0, 0, 0)
         end_date = datetime(2022, 3, 6, 0, 0, 0)
-        self.run_test(start_date, end_date, fake_make_request)
+        self.do_thing(start_date, end_date, fake_make_request)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -40,8 +40,6 @@ class TestEndDate(unittest.TestCase):
 
         if end_date:
             config["end_date"] = str(end_date)
-        else:
-            end_date = datetime.now()
 
         my_report_stream.sync(
             Mock(),


### PR DESCRIPTION
# Description of change
Adds the use of the optional end-date config property to report sync.

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
   - [X] wrote unit tests
   - [X] unit tests are passing
   
# Risks
- minimal; alpha integration

# Rollback steps
 - revert this branch
