### PR TITLE
Revert removal of metric compatibility removal

### DIFF
--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -205,6 +205,11 @@ def create_resource_schema(config):
                     field_to_check = field_root_resource or field_name
                     compared_field_to_check = compared_field_root_resource or compared_field
 
+                    # The `selectable_with` for any given metric will not include
+                    # any other metrics despite compatibility, so don't check those
+                    if field_name.startswith("metrics.") and compared_field.startswith("metrics."):
+                        continue
+
                     # If a resource is selectable with another resource they should be in
                     # each other's 'selectable_with' list, but Google is missing some of
                     # these so we have to check both ways
@@ -215,6 +220,7 @@ def create_resource_schema(config):
                         field["incompatible_fields"].append(compared_field)
 
         report_object["fields"] = fields
+
     return resource_schema
 
 

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -220,7 +220,6 @@ def create_resource_schema(config):
                         field["incompatible_fields"].append(compared_field)
 
         report_object["fields"] = fields
-
     return resource_schema
 
 


### PR DESCRIPTION
# Description of change
Reverts a change made in [PR 23](https://github.com/singer-io/tap-google-ads/pull/23) and adds clarity to its intention via code comment. Ensures metrics are not considered incompatible with other metrics.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
Minimal

# Rollback steps
 - revert this branch
