### PR TITLE
Conversion window validation

### DIFF
--- a/tests/test_google_ads_conversion_window_invalid.py
+++ b/tests/test_google_ads_conversion_window_invalid.py
@@ -117,8 +117,6 @@ class ConversionWindowTestZeroInteger(ConversionWindowInvalidTest):
 
     conversion_window = 0
 
-    @unittest.skip("https://jira.talendforge.org/browse/TDL-18168"
-                   "[tap-google-ads] Invalid conversion_window values can be set when running tap directly")
     def test_run(self):
         self.run_test()
 

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -1,6 +1,5 @@
 import unittest
 from tap_google_ads.streams import generate_hash
-from tap_google_ads.streams import get_conversion_window
 from tap_google_ads.streams import get_query_date
 from tap_google_ads.streams import create_nested_resource_schema
 from tap_google_ads.sync import shuffle
@@ -355,48 +354,6 @@ class TestShuffleCustomers(unittest.TestCase):
         ]
         self.assertListEqual(expected, actual)
 
-
-class TestGetConversionWindow(unittest.TestCase):
-    def test_int_conversion_date_in_allowable_range(self):
-        actual = get_conversion_window({"conversion_window": 12})
-        expected = 12
-        self.assertEqual(expected, actual)
-
-    def test_str_conversion_date_in_allowable_range(self):
-        actual = get_conversion_window({"conversion_window": "12"})
-        expected = 12
-        self.assertEqual(expected, actual)
-
-    def test_conversion_date_outside_allowable_range(self):
-        with self.assertRaises(RuntimeError):
-            get_conversion_window({"conversion_window": 42})
-
-        with self.assertRaises(RuntimeError):
-            get_conversion_window({"conversion_window": "42"})
-
-    def test_non_int_or_str_conversion_date(self):
-        with self.assertRaises(RuntimeError):
-            get_conversion_window({"conversion_window": {"12": 12}})
-
-        with self.assertRaises(RuntimeError):
-            get_conversion_window({"conversion_window": [12]})
-
-    def test_empty_data_types_conversion_date_returns_default(self):
-        expected = 30
-
-        actual = get_conversion_window({"conversion_window": ""})
-        self.assertEqual(expected, actual)
-
-        actual = get_conversion_window({"conversion_window": {}})
-        self.assertEqual(expected, actual)
-
-        actual = get_conversion_window({"conversion_window": []})
-        self.assertEqual(expected, actual)
-
-    def test_None_conversion_date_returns_default(self):
-        actual = get_conversion_window({"conversion_window": None})
-        expected = 30
-        self.assertEqual(expected, actual)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 from tap_google_ads.streams import generate_hash
+from tap_google_ads.streams import get_conversion_window
 from tap_google_ads.streams import get_query_date
 from tap_google_ads.streams import create_nested_resource_schema
 from tap_google_ads.sync import shuffle
@@ -353,6 +354,49 @@ class TestShuffleCustomers(unittest.TestCase):
             {"customerId": "customer4"},
         ]
         self.assertListEqual(expected, actual)
+
+
+class TestGetConversionWindow(unittest.TestCase):
+    def test_int_conversion_date_in_allowable_range(self):
+        actual = get_conversion_window({"conversion_window": 12})
+        expected = 12
+        self.assertEqual(expected, actual)
+
+    def test_str_conversion_date_in_allowable_range(self):
+        actual = get_conversion_window({"conversion_window": "12"})
+        expected = 12
+        self.assertEqual(expected, actual)
+
+    def test_conversion_date_outside_allowable_range(self):
+        with self.assertRaises(RuntimeError):
+            get_conversion_window({"conversion_window": 42})
+
+        with self.assertRaises(RuntimeError):
+            get_conversion_window({"conversion_window": "42"})
+
+    def test_non_int_or_str_conversion_date(self):
+        with self.assertRaises(RuntimeError):
+            get_conversion_window({"conversion_window": {"12": 12}})
+
+        with self.assertRaises(RuntimeError):
+            get_conversion_window({"conversion_window": [12]})
+
+    def test_empty_data_types_conversion_date_returns_default(self):
+        expected = 30
+
+        actual = get_conversion_window({"conversion_window": ""})
+        self.assertEqual(expected, actual)
+
+        actual = get_conversion_window({"conversion_window": {}})
+        self.assertEqual(expected, actual)
+
+        actual = get_conversion_window({"conversion_window": []})
+        self.assertEqual(expected, actual)
+
+    def test_None_conversion_date_returns_default(self):
+        actual = get_conversion_window({"conversion_window": None})
+        expected = 30
+        self.assertEqual(expected, actual)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description of change
This PR adds validation in the tap for `conversion_window` when we parse it from the config.

It also adds tests for various things you can put in the config. This hopefully sheds light on when the tap will fail and when it will not.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- Low. If anything it clarifies the error from `Can't int a dictionary` to `Conversion Window must be an int or string`

# Rollback steps
 - revert this branch
