### PR TITLE
This field is never compatible with our segments.date query, so remove it

### DIFF
--- a/tap_google_ads/report_definitions.py
+++ b/tap_google_ads/report_definitions.py
@@ -542,7 +542,6 @@ AD_GROUP_AUDIENCE_PERFORMANCE_REPORT_FIELDS = [
     "segments.slot",
     "segments.week",
     "segments.year",
-    "user_list.name",
 ]
 CAMPAIGN_AUDIENCE_PERFORMANCE_REPORT_FIELDS = [
     "bidding_strategy.name",
@@ -614,7 +613,6 @@ CAMPAIGN_AUDIENCE_PERFORMANCE_REPORT_FIELDS = [
     "segments.slot",
     "segments.week",
     "segments.year",
-    "user_list.name",
 ]
 CAMPAIGN_PERFORMANCE_REPORT_FIELDS = [
     "bidding_strategy.name",


### PR DESCRIPTION
# Description of change
This PR removes a field that is incompatible with `segments.date` which we always use in our queries.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
