### PR TITLE
Update to v10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='tap-google-ads',
           'singer-python==5.12.2',
           'requests==2.26.0',
           'backoff==1.8.0',
-          'google-ads==14.1.0',
+          'google-ads==15.0.0',
           'protobuf==3.17.3',
       ],
       extras_require= {

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -7,8 +7,6 @@ from tap_google_ads.client import create_sdk_client
 from tap_google_ads.streams import initialize_core_streams
 from tap_google_ads.streams import initialize_reports
 
-API_VERSION = "v9"
-
 LOGGER = singer.get_logger()
 
 REPORTS = [

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -14,6 +14,10 @@ LOGGER = singer.get_logger()
 
 API_VERSION = "v10"
 
+API_PARAMETERS = {
+    "omit_unselected_resource_names": "true"
+}
+
 REPORTS_WITH_90_DAY_MAX = frozenset(
     [
         "click_performance_report",
@@ -72,8 +76,13 @@ def get_selected_fields(stream_mdata):
     return selected_fields
 
 
+def build_parameters():
+    param_str = ",".join(f"{k}={v}" for k, v in API_PARAMETERS.items())
+    return f"PARAMETERS {param_str}"
+
+
 def create_core_stream_query(resource_name, selected_fields):
-    core_query = f"SELECT {','.join(selected_fields)} FROM {resource_name}"
+    core_query = f"SELECT {','.join(selected_fields)} FROM {resource_name} {build_parameters()}"
     return core_query
 
 
@@ -81,7 +90,7 @@ def create_report_query(resource_name, selected_fields, query_date):
 
     format_str = "%Y-%m-%d"
     query_date = utils.strftime(query_date, format_str=format_str)
-    report_query = f"SELECT {','.join(selected_fields)} FROM {resource_name} WHERE segments.date = '{query_date}'"
+    report_query = f"SELECT {','.join(selected_fields)} FROM {resource_name} WHERE segments.date = '{query_date}' {build_parameters()}"
 
     return report_query
 

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -12,7 +12,7 @@ from . import report_definitions
 
 LOGGER = singer.get_logger()
 
-API_VERSION = "v9"
+API_VERSION = "v10"
 
 REPORTS_WITH_90_DAY_MAX = frozenset(
     [

--- a/tests/unittests/test_conversion_window.py
+++ b/tests/unittests/test_conversion_window.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from datetime import datetime
 from datetime import timedelta
@@ -78,7 +79,7 @@ class TestBookmarkWithinConversionWindow(unittest.TestCase):
 
         # Verify the first date queried is the conversion window date (not the bookmark)
         expected_first_query_date = str(end_date - timedelta(days=conversion_window))[:10]
-        actual_first_query_date = str(all_queries_requested[0])[-11:-1]
+        actual_first_query_date = re.search(r'\d\d\d\d-\d\d-\d\d', all_queries_requested[0]).group()
         self.assertEqual(expected_first_query_date, actual_first_query_date)
 
         # Verify the number of days queried is based off the conversion window.
@@ -152,7 +153,7 @@ class TestBookmarkOnConversionWindow(unittest.TestCase):
 
         # Verify the first date queried is the conversion window date / bookmark
         expected_first_query_date = str(bookmark_value)[:10]
-        actual_first_query_date = str(all_queries_requested[0])[-11:-1]
+        actual_first_query_date = re.search(r'\d\d\d\d-\d\d-\d\d', all_queries_requested[0]).group()
         self.assertEqual(expected_first_query_date, actual_first_query_date)
 
         # Verify the number of days queried is based off the conversion window.
@@ -222,7 +223,7 @@ class TestStartDateWithinConversionWindow(unittest.TestCase):
 
         # Verify the first date queried is the conversion window date (not the bookmark)
         expected_first_query_date = str(start_date)[:10]
-        actual_first_query_date = str(all_queries_requested[0])[-11:-1]
+        actual_first_query_date = re.search(r'\d\d\d\d-\d\d-\d\d', all_queries_requested[0]).group()
         self.assertEqual(expected_first_query_date, actual_first_query_date)
 
         # Verify the number of days queried is based off the start_date


### PR DESCRIPTION
# Description of change
Update google ads library to v10 ([release notes](https://developers.google.com/google-ads/api/docs/release-notes)).
This allows us to remove `resource_name` from the google ads response so the transformer not as noisy as `resource_name` is not in the schema.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 - Inspected response from google ads and saw no resource_name property.
 - Ran a sync to ensure Transformer is no longer removing the path `resource_name` since it no longer exists. 
# Risks
Low. Removing unused field.
# Rollback steps
 - revert this branch
