### PR TITLE
Change `_sdc_record_hash` to sorted list of tuples

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -97,12 +97,12 @@ def create_report_query(resource_name, selected_fields, query_date):
 
 def generate_hash(record, metadata):
     metadata = singer.metadata.to_map(metadata)
-    fields_to_hash = {}
+    fields_to_hash = []
     for key, val in record.items():
         if metadata[("properties", key)]["behavior"] != "METRIC":
-            fields_to_hash[key] = val
+            fields_to_hash.append((key, val))
 
-    hash_source_data = {key: fields_to_hash[key] for key in sorted(fields_to_hash)}
+    hash_source_data = sorted(fields_to_hash, key=lambda x: x[0])
     hash_bytes = json.dumps(hash_source_data).encode("utf-8")
     return hashlib.sha256(hash_bytes).hexdigest()
 

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -123,7 +123,7 @@ class TestRecordHashing(unittest.TestCase):
         ('properties', 'date'): {'behavior': 'SEGMENT'},
     })
 
-    expected_hash = 'ade8240f134633fe125388e469e61ccf9e69033fd5e5f166b4b44766bc6376d3'
+    expected_hash = '38d95857633f1e04092f7a308f0d3777d965cba80a5593803dd2b7e4a484ce64'
 
     def test_record_hash_canary(self):
         self.assertEqual(self.expected_hash, generate_hash(self.test_record, self.test_metadata))


### PR DESCRIPTION
# Description of change
This PR makes `generate_hash` be more explicit about the order of the list we hash.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
