### PR TITLE
Add date ranges for report data

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,8 @@
 
 # QA steps
  - [ ] automated tests passing
- - [ ] manual qa steps passing (list below)
- 
+ - [ ] manual qa steps passing (See: tap-tester/reference/manual_tests)
+
 # Risks
 
 # Rollback steps

--- a/tests/test_google_ads_sync_canary.py
+++ b/tests/test_google_ads_sync_canary.py
@@ -35,6 +35,58 @@ class SyncCanaryTest(GoogleAdsBase):
             'ad_group_audience_performance_report',  # Potential BUG see above
         }
 
+        """
+        Test Data available for the following report streams across the following dates (only the
+        first and last date that data was generated is listed).
+
+        $ jq 'select(.table_name | contains("report")) | .table_name,.messages[0].data.date,
+              .messages[-1].data.date' /tmp/tap-tester-target-out.json
+        "account_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "ad_group_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "ad_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "age_range_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "campaign_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "click_performance_report"
+        "2021-12-30T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "expanded_landing_page_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "gender_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "geo_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "keywordless_query_report"
+        "2022-01-20T00:00:00.000000Z"
+        "2022-01-25T00:00:00.000000Z"
+        "landing_page_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        "placeholder_feed_item_report"
+        "2021-12-07T00:00:00.000000Z"
+        "2021-12-31T00:00:00.000000Z"
+        "placeholder_report"
+        "2021-12-07T00:00:00.000000Z"
+        "2021-12-31T00:00:00.000000Z"
+        "search_query_performance_report"
+        "2022-01-20T00:00:00.000000Z"
+        "2022-01-25T00:00:00.000000Z"
+        "user_location_performance_report"
+        "2021-12-06T00:00:00.000000Z"
+        "2022-03-14T00:00:00.000000Z"
+        """
         # Run a discovery job
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         test_catalogs = [catalog for catalog in found_catalogs if catalog['stream_name'] in streams_to_test]

--- a/tests/test_google_ads_sync_canary.py
+++ b/tests/test_google_ads_sync_canary.py
@@ -18,24 +18,7 @@ class SyncCanaryTest(GoogleAdsBase):
     def test_run(self):
         """
         Testing that basic sync functions without Critical Errors
-        """
-        print("Canary Sync Test for tap-google-ads")
 
-        conn_id = connections.ensure_connection(self)
-
-        streams_to_test = self.expected_streams() - {
-            # TODO_TDL-17885 the following are not yet implemented
-            'display_keyword_performance_report', # no test data available
-            'display_topics_performance_report',  # no test data available
-            'placement_performance_report',  # no test data available
-            "keywords_performance_report",  # no test data available
-            "video_performance_report",  # no test data available
-            "shopping_performance_report",  # no test data available (need Shopping campaign type)
-            'campaign_audience_performance_report', # no test data available
-            'ad_group_audience_performance_report',  # Potential BUG see above
-        }
-
-        """
         Test Data available for the following report streams across the following dates (only the
         first and last date that data was generated is listed).
 
@@ -87,6 +70,22 @@ class SyncCanaryTest(GoogleAdsBase):
         "2021-12-06T00:00:00.000000Z"
         "2022-03-14T00:00:00.000000Z"
         """
+        print("Canary Sync Test for tap-google-ads")
+
+        conn_id = connections.ensure_connection(self)
+
+        streams_to_test = self.expected_streams() - {
+            # TODO_TDL-17885 the following are not yet implemented
+            'display_keyword_performance_report', # no test data available
+            'display_topics_performance_report',  # no test data available
+            'placement_performance_report',  # no test data available
+            "keywords_performance_report",  # no test data available
+            "video_performance_report",  # no test data available
+            "shopping_performance_report",  # no test data available (need Shopping campaign type)
+            'campaign_audience_performance_report', # no test data available
+            'ad_group_audience_performance_report',  # Potential BUG see above
+        }
+
         # Run a discovery job
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         test_catalogs = [catalog for catalog in found_catalogs if catalog['stream_name'] in streams_to_test]


### PR DESCRIPTION
# Description of change
Document date ranges for report streams where data has been generated inside the sync_canary test for future reference.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
