### PR TITLE
Bump to v1.0.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.0
+  * Version bump for GA release
+  * Adds fields to click_view report definition [#44](https://github.com/singer-io/tap-google-ads/pull/44)
+  * Adds date ranges to tests for faster test runs [#43](https://github.com/singer-io/tap-google-ads/pull/43)
+  * Adds more tests around primary key hashing [#42](https://github.com/singer-io/tap-google-ads/pull/42)
+
 ## v0.3.0
   * Removes unused code
   * Adds a behavior to "_sdc_record_hash"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='0.3.0',
+      version='1.0.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
  - Version bump to v1.0.0 for release.

# Changes
  - Adds fields to click_view report definition [#44](https://github.com/singer-io/tap-google-ads/pull/44)
  - Adds date ranges to tests for faster test runs [#43](https://github.com/singer-io/tap-google-ads/pull/43)
  - Adds more tests around primary key hashing [#42](https://github.com/singer-io/tap-google-ads/pull/42)

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (See: tap-tester/reference/manual_tests)

# Risks
Just a version bump.

# Rollback steps
 - revert this branch
