### PR TITLE
Version bump and changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.1.0
+  * Adds call_details core stream and removes segmenting resources from core streams [#49](https://github.com/singer-io/tap-google-ads/pull/49)
+
 ## v1.0.0
   * Version bump for GA release
   * Adds fields to click_view report definition [#44](https://github.com/singer-io/tap-google-ads/pull/44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v1.1.0
+  * Fixes a bug with currently_syncing and adds tests around the bug fix [#54](https://github.com/singer-io/tap-google-ads/pull/54)
   * Adds `campaign_labels` and `labels` core streams; adds "campaign.labels" field to reports where relevant [#53](https://github.com/singer-io/tap-google-ads/pull/53)
   * Adds `call_details` core stream and removes segmenting resources from core streams [#49](https://github.com/singer-io/tap-google-ads/pull/49)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## v1.1.0
-  * Adds call_details core stream and removes segmenting resources from core streams [#49](https://github.com/singer-io/tap-google-ads/pull/49)
+  * Adds `campaign_labels` and `labels` core streams; adds "campaign.labels" field to reports where relevant [#53](https://github.com/singer-io/tap-google-ads/pull/53)
+  * Adds `call_details` core stream and removes segmenting resources from core streams [#49](https://github.com/singer-io/tap-google-ads/pull/49)
 
 ## v1.0.0
   * Version bump for GA release

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.0.0',
+      version='1.1.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Version bump and changelog entry for [PR 49](https://github.com/singer-io/tap-google-ads/pull/49) and [PR 53](https://github.com/singer-io/tap-google-ads/pull/53)

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing

# Risks
- None

# Rollback steps
 - revert this branch
