### PR TITLE
Qa/fix build notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             pip install 'setuptools==56.0.0'
             pip install .[dev]
       - slack/notify-on-failure:
-          only_for_branches: master
+          only_for_branches: main
       - persist_to_workspace:
           root: /usr/local/share/virtualenvs
           paths:
@@ -45,7 +45,7 @@ jobs:
             echo "$PYLINT_DISABLE_LIST"
             pylint tap_google_ads --disable "$PYLINT_DISABLE_LIST"
       - slack/notify-on-failure:
-          only_for_branches: master
+          only_for_branches: main
 
   run_unit_tests:
     executor: docker-executor
@@ -65,7 +65,7 @@ jobs:
       - store_artifacts:
           path: htmlcov
       - slack/notify-on-failure:
-          only_for_branches: master
+          only_for_branches: main
 
   run_integration_tests:
     executor: docker-executor
@@ -89,7 +89,7 @@ jobs:
               done
             fi
       - slack/notify-on-failure:
-          only_for_branches: master
+          only_for_branches: main
 
 workflows:
   version: 2

--- a/tests/test_google_ads_automatic_fields.py
+++ b/tests/test_google_ads_automatic_fields.py
@@ -80,18 +80,19 @@ class AutomaticFieldsGoogleAds(GoogleAdsBase):
         streams_to_test = {stream for stream in self.expected_streams()
                            if stream not in {
                                    # no test data available, but can generate
+                                   "keywords_performance_report",  # needs a Search Campaign (currently have none)
+                                   'click_performance_report',  # only last 90 days returned
                                    'display_keyword_performance_report',  # Singer Display #2, Ad Group 2
                                    'display_topics_performance_report',  # Singer Display #2, Ad Group 2
-                                   "keywords_performance_report",  # needs a Search Campaign (currently have none)
                                    # audiences are unclear on how metrics fall into segments
-                                   'campaign_audience_performance_report',  # Singer Display #2/Singer Display, Ad Group 2 (maybe?)
                                    'ad_group_audience_performance_report',  # Singer Display #2/Singer Display, Ad Group 2 (maybe?)
+                                   'campaign_audience_performance_report',  # Singer Display #2/Singer Display, Ad Group 2 (maybe?)
                                    # cannot generate test data
-                                   'placement_performance_report',  # need an app to run javascript to trace conversions
-                                   "video_performance_report",  # need a video to show
-                                   "shopping_performance_report",  # need Shopping campaign type, and link to a store
                                    "call_details", # need test call data before data will be returned
+                                   "shopping_performance_report",  # need Shopping campaign type, and link to a store
                                    "shopping_performance_report", # No automatic keys for this report
+                                   "video_performance_report",  # need a video to show
+                                   'placement_performance_report',  # need an app to run javascript to trace conversions
                            }}
 
         # Run a discovery job

--- a/tests/test_google_ads_bookmarks.py
+++ b/tests/test_google_ads_bookmarks.py
@@ -46,6 +46,9 @@ class BookmarksTest(GoogleAdsBase):
 
         streams_under_test = self.expected_streams() - {
             'ad_group_audience_performance_report',
+            'call_details', # need test call data before data will be returned
+            'campaign_audience_performance_report',
+            'click_performance_report',  # only last 90 days returned
             'display_keyword_performance_report',
             'display_topics_performance_report',
             'keywords_performance_report',
@@ -53,8 +56,6 @@ class BookmarksTest(GoogleAdsBase):
             'search_query_performance_report',
             'shopping_performance_report',
             'video_performance_report',
-            'campaign_audience_performance_report',
-            'call_details', # need test call data before data will be returned
         }
 
         # Run a discovery job
@@ -93,7 +94,6 @@ class BookmarksTest(GoogleAdsBase):
             'placeholder_feed_item_report': data_set_state_value_2,
             'age_range_performance_report': data_set_state_value_1,
             'account_performance_report': data_set_state_value_1,
-            'click_performance_report': data_set_state_value_1,
             'campaign_performance_report': data_set_state_value_1,
             'placeholder_report': data_set_state_value_2,
             'ad_performance_report': data_set_state_value_1,

--- a/tests/test_google_ads_start_date.py
+++ b/tests/test_google_ads_start_date.py
@@ -148,15 +148,16 @@ class StartDateTest(GoogleAdsBase):
 class StartDateTest1(StartDateTest):
 
     missing_coverage_streams = { # no test data available
+        'ad_group_audience_performance_report',
+        'call_details',
+        'campaign_audience_performance_report',
+        'click_performance_report',  # only last 90 days returned
         'display_keyword_performance_report',
         'display_topics_performance_report',
+        'keywords_performance_report',
         'placement_performance_report',
-        "keywords_performance_report",
-        "video_performance_report",
-        'ad_group_audience_performance_report',
-        "shopping_performance_report",
-        'campaign_audience_performance_report',
-        'call_details',
+        'shopping_performance_report',
+        'video_performance_report',
     }
 
     def setUp(self):


### PR DESCRIPTION
# Description of change
Fix build notifications, remove `click_performance_report` stream from tests that can no longer be covered.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing

# Risks

# Rollback steps
 - revert this branch
