### PR TITLE
Make tap-tester suite use end_date to reduce test runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,8 @@ jobs:
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
+            mkdir /tmp/${CIRCLE_PROJECT_REPONAME}
+            export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             circleci tests glob "tests/*.py" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
@@ -90,6 +92,8 @@ jobs:
             fi
       - slack/notify-on-failure:
           only_for_branches: main
+      - store_artifacts:
+          path: /tmp/tap-google-ads
 
 workflows:
   version: 2

--- a/tests/base.py
+++ b/tests/base.py
@@ -30,7 +30,7 @@ class GoogleAdsBase(unittest.TestCase):
     REPLICATION_KEY_FORMAT = "%Y-%m-%dT00:00:00.000000Z"
 
     start_date = ""
-    end_date = "2022-04-01T00:00:00Z"
+    end_date = "2022-03-15T00:00:00Z"
 
     @staticmethod
     def tap_name():

--- a/tests/base.py
+++ b/tests/base.py
@@ -30,6 +30,7 @@ class GoogleAdsBase(unittest.TestCase):
     REPLICATION_KEY_FORMAT = "%Y-%m-%dT00:00:00.000000Z"
 
     start_date = ""
+    end_date = "2022-04-01T00:00:00Z"
 
     @staticmethod
     def tap_name():
@@ -51,6 +52,7 @@ class GoogleAdsBase(unittest.TestCase):
         """Configurable properties, with a switch to override the 'start_date' property"""
         return_value = {
             'start_date':   '2021-12-01T00:00:00Z',
+            'end_date': self.end_date,
             'user_id':      'not used?',  # Useless config property carried over from AdWords
             'customer_ids': ','.join(self.get_customer_ids()),
             # 'conversion_window_days': '30',

--- a/tests/base_google_ads_field_exclusion.py
+++ b/tests/base_google_ads_field_exclusion.py
@@ -61,6 +61,7 @@ class FieldExclusionGoogleAdsBase(GoogleAdsBase):
 
         # bump start date from default
         self.start_date = dt.strftime(dt.today() - timedelta(days=1), self.START_DATE_FORMAT)
+        self.end_date = None
         conn_id = connections.ensure_connection(self, original_properties=False)
 
         # Run a discovery job

--- a/tests/test_google_ads_bookmarks.py
+++ b/tests/test_google_ads_bookmarks.py
@@ -32,7 +32,7 @@ class BookmarksTest(GoogleAdsBase):
     def test_run(self):
         """
         Testing that the tap sets and uses bookmarks correctly where
-        state < (end_date - converstion window), therefore the state should be used
+        state < (today - converstion window), therefore the state should be used
         on sync 2
 
         Note:

--- a/tests/test_google_ads_field_exclusion_invalid.py
+++ b/tests/test_google_ads_field_exclusion_invalid.py
@@ -93,6 +93,7 @@ class FieldExclusionInvalidGoogleAds(GoogleAdsBase):
 
         # bump start date from default
         self.start_date = dt.strftime(dt.today() - timedelta(days=1), self.START_DATE_FORMAT)
+        self.end_date = None
         conn_id = connections.ensure_connection(self, original_properties=False)
 
         # Run a discovery job

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -119,5 +119,16 @@ class TestEndDate(unittest.TestCase):
                 )
             )
 
+    @patch('tap_google_ads.streams.make_request')
+    def test_end_date_one_day_before_start(self, fake_make_request):
+        start_date = datetime(2022, 3, 6, 0, 0, 0)
+        end_date = datetime(2022, 3, 5, 0, 0, 0)
+        self.run_sync(start_date, end_date, fake_make_request)
+        all_queries_requested = self.get_queries_from_sync(fake_make_request)
+
+        # verify no requests are made with an invalid start/end date configuration
+        self.assertEqual(len(all_queries_requested), 0)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description of change
Add end_date to base.py so that incremental streams under test stop requests at 04/01/22 to reduce runtime.

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing
  - ran test suite locally
# Risks

# Rollback steps
 - revert this branch
