### PR TITLE
TDL-21755 Version bump and changelog for PR 79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.4
+  * Updates API Version to 11
+  * Updates pkg version to 17.0.0
+  * [#79](https://github.com/singer-io/tap-google-ads/pull/79)
+
 ## v1.3.3
   * Update applicable core streams to use limit clause. Updates tests [#68](https://github.com/singer-io/tap-google-ads/pull/68)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.3.3',
+      version='1.3.4',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Version bump and changelog for [PR 79](https://github.com/singer-io/tap-google-ads/pull/79)

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing

# Risks
Must be released with PR 79

# Rollback steps
 - revert this branch
