### PR TITLE
google-ads updated api version to V13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.5.0
+  * Updates API version to 13
+  * Updates pkg version to 21.0.0
+
 
 ## v1.4.0
   * Updates API version to 12

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.4.0',
+      version='1.5.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',
@@ -13,8 +13,8 @@ setup(name='tap-google-ads',
           'singer-python==5.12.2',
           'requests==2.26.0',
           'backoff==1.8.0',
-          'google-ads==19.0.0',
-          'protobuf==4.21.5',
+          'google-ads==21.0.0',
+          'protobuf==4.22.3',
 
           # Necessary to handle gRPC exceptions properly, documented
           # in an issue here: https://github.com/googleapis/python-api-core/issues/301

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -14,7 +14,7 @@ from . import report_definitions
 
 LOGGER = singer.get_logger()
 
-API_VERSION = "v12"
+API_VERSION = "v13"
 
 API_PARAMETERS = {
     "omit_unselected_resource_names": "true"


### PR DESCRIPTION
# Description of change
- Bump package version to 21.0.0
- Api version upgrade to V13


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing

# Risks

# Rollback steps
 - revert this branch
