### PR TITLE
Python upgrade 3.11.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-3-11-dev
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-3-11-dev
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-google-ads
             source /usr/local/share/virtualenvs/tap-google-ads/bin/activate
-            pip install 'pip==21.1.3'
+            pip install 'pip==23.3.2'
             pip install 'setuptools==56.0.0'
             pip install .[dev]
       - slack/notify-on-failure:
@@ -57,9 +57,8 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-google-ads/bin/activate
-            pip install nose coverage
-            nosetests --with-coverage --cover-erase --cover-package=tap_google_ads --cover-html-dir=htmlcov tests/unittests
-            coverage html
+            pip install nose2
+            nose2 -v -s tests/unittests
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.7.0
+  * Run on python 3.11.7 [#88](https://github.com/singer-io/tap-google-ads/pull/88)
+
 ## v1.6.0
   * Updates API version to 15
   * Updates pkg version to 22.1.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.6.1',
+      version='1.7.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.6.0',
+      version='1.6.1',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_google_ads'],
       install_requires=[
-          'singer-python==5.12.2',
+          'singer-python==6.0.0',
           'requests==2.26.0',
           'backoff==1.8.0',
           'google-ads==22.1.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-google-ads',
       install_requires=[
           'singer-python==6.0.0',
           'requests==2.26.0',
-          'backoff==1.8.0',
+          'backoff==2.2.1',
           'google-ads==22.1.0',
           'protobuf==4.24.4',
 


### PR DESCRIPTION
# Description of change
Update tap's libraries and circle config to run on python 3.11.7

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing

# Risks
Any code not covered by tests could have incompatibilities with python 3.11
# Rollback steps
 - revert this branch
