### PR TITLE
Upgrade to Google Ads API v17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.8.0
+  * Updates API version to 17
+  * Updates pkg version to 25.0.0
+  * [#93](https://github.com/singer-io/tap-google-ads/pull/93)
+
 ## v1.7.0
   * Run on python 3.11.7 [#88](https://github.com/singer-io/tap-google-ads/pull/88)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.7.0',
+      version='1.8.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',
@@ -13,12 +13,12 @@ setup(name='tap-google-ads',
           'singer-python==6.0.0',
           'requests==2.26.0',
           'backoff==2.2.1',
-          'google-ads==22.1.0',
-          'protobuf==4.24.4',
+          'google-ads==25.0.0',
+          'protobuf==5.28.0',
 
           # Necessary to handle gRPC exceptions properly, documented
           # in an issue here: https://github.com/googleapis/python-api-core/issues/301
-          'grpcio-status==1.44.0',
+          'grpcio-status==1.66.1',
       ],
       extras_require= {
           'dev': [

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -14,7 +14,7 @@ from . import report_definitions
 
 LOGGER = singer.get_logger()
 
-API_VERSION = "v15"
+API_VERSION = "v17"
 
 API_PARAMETERS = {
     "omit_unselected_resource_names": "true"


### PR DESCRIPTION
# Description of change
- Updates Google Ads SDK to version 25.0.0
- Upgrades Google Ads API to version v17 (as v15 will be deprecated on September 25, 2024 [ref doc link](https://developers.google.com/google-ads/api/docs/sunset-dates))
- Updates protobuf and grpcio-status package versions


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing

# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
