### PR TITLE
SAC-28234: Use `uv`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,23 +27,18 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: main
       - persist_to_workspace:
-          root: /usr/local/share/virtualenvs
+          root: /
           paths:
-            - tap-google-ads
-      - persist_to_workspace:
-          root: /root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu
-          paths:
-            - bin
-            - lib
+            - root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/bin
+            - root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib
+            - usr/local/share/virtualenvs/tap-google-ads
 
   run_pylint:
     executor: docker-executor
     steps:
       - checkout
       - attach_workspace:
-          at: /usr/local/share/virtualenvs
-      - attach_workspace:
-          at: /root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu
+          at: /
       - run:
           name: 'Run pylint'
           command: |
@@ -62,7 +57,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /usr/local/share/virtualenvs
+          at: /
       - run:
           name: 'Run Unit Tests'
           command: |
@@ -82,7 +77,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /usr/local/share/virtualenvs
+          at: /
       - run:
           name: 'Run Integration Tests'
           no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,9 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-google-ads/bin/activate
-            pip install nose2
-            nose2 -v -s tests/unittests
+            uv pip install pytest coverage
+            coverage run -m pytest tests/unittests
+            coverage html
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:
@@ -82,6 +83,7 @@ jobs:
           name: 'Run Integration Tests'
           no_output_timeout: 30m
           command: |
+            source /usr/local/share/virtualenvs/tap-google-ads/bin/activate
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             mkdir /tmp/${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,12 +116,12 @@ workflows:
             - tier-1-tap-user
           requires:
             - ensure_env
-      - run_integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          requires:
-            - ensure_env
+      # - run_integration_tests:
+      #     context:
+      #       - circleci-user
+      #       - tier-1-tap-user
+      #     requires:
+      #       - ensure_env
       - build:
           context:
             - circleci-user
@@ -129,7 +129,7 @@ workflows:
           requires:
             - run_pylint
             - run_unit_tests
-            - run_integration_tests
+            # - run_integration_tests
   build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
             uv pip install 'pip==23.3.2'
             uv pip install 'setuptools==56.0.0'
             uv pip install .[dev]
+            uv pip install awscli --upgrade
       - slack/notify-on-failure:
           only_for_branches: main
       - persist_to_workspace:
@@ -43,7 +44,6 @@ jobs:
           name: 'Run pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-google-ads/bin/activate
-            uv pip install awscli --upgrade
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             echo "$PYLINT_DISABLE_LIST"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,19 @@ jobs:
           root: /usr/local/share/virtualenvs
           paths:
             - tap-google-ads
+      - persist_to_workspace:
+          root: /root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu
+          paths:
+            - bin
+
   run_pylint:
     executor: docker-executor
     steps:
       - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs
+      - attach_workspace:
+          at: /root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu
       - run:
           name: 'Run pylint'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/bin
-            - root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib
+            - root/.local/share/uv/python
             - usr/local/share/virtualenvs/tap-google-ads
 
   run_pylint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
           root: /root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu
           paths:
             - bin
+            - lib
 
   run_pylint:
     executor: docker-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,12 +121,12 @@ workflows:
             - tier-1-tap-user
           requires:
             - ensure_env
-      # - run_integration_tests:
-      #     context:
-      #       - circleci-user
-      #       - tier-1-tap-user
-      #     requires:
-      #       - ensure_env
+      - run_integration_tests:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - ensure_env
       - build:
           context:
             - circleci-user
@@ -134,7 +134,7 @@ workflows:
           requires:
             - run_pylint
             - run_unit_tests
-            # - run_integration_tests
+            - run_integration_tests
   build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
 
 jobs:
   build:
@@ -19,11 +19,11 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-google-ads
+            uv venv --python 3.11 /usr/local/share/virtualenvs/tap-google-ads
             source /usr/local/share/virtualenvs/tap-google-ads/bin/activate
-            pip install 'pip==23.3.2'
-            pip install 'setuptools==56.0.0'
-            pip install .[dev]
+            uv pip install 'pip==23.3.2'
+            uv pip install 'setuptools==56.0.0'
+            uv pip install .[dev]
       - slack/notify-on-failure:
           only_for_branches: main
       - persist_to_workspace:
@@ -40,9 +40,11 @@ jobs:
           name: 'Run pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-google-ads/bin/activate
+            uv pip install awscli --upgrade
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             echo "$PYLINT_DISABLE_LIST"
+            uv pip install pylint
             pylint tap_google_ads --disable "$PYLINT_DISABLE_LIST,too-many-positional-arguments"
       - slack/notify-on-failure:
           only_for_branches: main


### PR DESCRIPTION
# Description of change
This PR updates the config to support installing python via `uv`.

The important parts are that we persist the python executable that `uv` installs and the standard library.

```
      - persist_to_workspace:
          root: /
          paths:
            - root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/bin
            - root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib
            - usr/local/share/virtualenvs/tap-google-ads
```

And then any step that needs to use the virtualenv needs to just have an `attach` step

```
      - attach_workspace:
          at: /
```

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing
 - Iterated in CI until the build was able to run

# Risks
- Low. All of the changes should functionally be the same as the they were before. The platform is just a little different

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
