### PR TITLE
Upgrade protobuf to 7.34.1 and remove grpcio-status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='tap-google-ads',
           'requests==2.34.2',
           'backoff==2.2.1',
           'google-ads==30.1.0',
-          'protobuf==6.33.6',
+          'protobuf==7.34.1',
       ],
       extras_require= {
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,6 @@ setup(name='tap-google-ads',
           'backoff==2.2.1',
           'google-ads==30.1.0',
           'protobuf==6.33.6',
-
-          # Necessary to handle gRPC exceptions properly, documented
-          # in an issue here: https://github.com/googleapis/python-api-core/issues/301
-          'grpcio-status==1.73.1',
       ],
       extras_require= {
           'dev': [


### PR DESCRIPTION
# Description of change
Upgrade protobuf to 7.34.1 to address [CVE-2026-0994](https://app.circleci.com/pipelines/github/stitchdata/deploy-taps/556/workflows/d6920460-1668-475a-aac8-a57b5f9b6cfb/jobs/531)(protobuf DoS vulnerability)
Removed the explicit `grpcio-status` dependency pin from `setup.py`

**Why**

- grpcio-status is not directly imported or used anywhere in the tap-google-ads source code — it's a transitive dependency of google-ads.
- The explicit pin to 1.73.1 was blocking resolution of [CVE-2026-0994](https://app.circleci.com/pipelines/github/stitchdata/deploy-taps/556/workflows/d6920460-1668-475a-aac8-a57b5f9b6cfb/jobs/531)(protobuf DoS vulnerability), because grpcio-status constrains [protobuf<7.0.0](https://github.com/grpc/grpc/blob/master/requirements.txt#L5).
- google-ads==30.1.0 already declares [grpcio-status as a dependency](https://github.com/googleads/google-ads-python/blob/main/pyproject.toml#L52), so pip will still install a compatible version automatically.
- The [referenced issue](https://github.com/googleapis/python-api-core/issues/301) about gRPC exception handling is handled by the transitive dependency— an explicit pin seems unnecessary.


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing

# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
